### PR TITLE
Fix CI deploy: use docker compose v2 plugin

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,14 +15,6 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
 
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
-
-            - name: Install Docker Compose
-              run: |
-                  sudo curl -L "https://github.com/docker/compose/releases/download/2.24.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-                  sudo chmod +x /usr/local/bin/docker-compose
-
             - name: Set up Node.js
               uses: actions/setup-node@v4
               with:
@@ -37,21 +29,21 @@ jobs:
 
             - name: Start Docker services
               run: |
-                  docker-compose up -d db
-                  docker-compose up -d wordpress
+                  docker compose up -d db
+                  docker compose up -d wordpress
 
             - name: Wait for services to be ready
               run: |
-                  timeout 60 bash -c 'until docker-compose exec -T db mysqladmin ping -h"localhost" -u"root" -p"password" --silent; do sleep 2; done'
+                  timeout 60 bash -c 'until docker compose exec -T db mysqladmin ping -h"localhost" -u"root" -p"password" --silent; do sleep 2; done'
                   timeout 60 bash -c 'until curl -f http://localhost:8080 >/dev/null 2>&1; do sleep 2; done'
 
             - name: Run tests
               run: |
-                  docker-compose run --rm test ci --coverage-enabled --generate-reports --coverage-dir coverage --test-reports-dir test-reports
+                  docker compose run --rm test ci --coverage-enabled --generate-reports --coverage-dir coverage --test-reports-dir test-reports
 
             - name: Stop services
               if: always()
-              run: docker-compose down
+              run: docker compose down
 
     build-and-deploy:
         name: Build and Deploy

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,10 +1,10 @@
 name: Docker-Based Testing
 
 on:
-  pull_request:
-    branches:
-      - main
-      - master
+    pull_request:
+        branches:
+            - main
+            - master
     push:
         branches:
             - main
@@ -12,7 +12,6 @@ on:
     workflow_dispatch:
 
 env:
-    DOCKER_COMPOSE_VERSION: '2.24.0'
     PHP_VERSION: '8.4'
     NODE_VERSION: '20'
 
@@ -25,14 +24,6 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
 
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
-
-            - name: Install Docker Compose
-              run: |
-                  sudo curl -L "https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-                  sudo chmod +x /usr/local/bin/docker-compose
-
             - name: Set up Node.js
               uses: actions/setup-node@v4
               with:
@@ -47,12 +38,12 @@ jobs:
 
             - name: Start Docker services
               run: |
-                  docker-compose up -d db
-                  docker-compose up -d wordpress
+                  docker compose up -d db
+                  docker compose up -d wordpress
 
             - name: Wait for services to be ready
               run: |
-                  timeout 60 bash -c 'until docker-compose exec -T db mysqladmin ping -h"localhost" -u"root" -p"password" --silent; do sleep 2; done'
+                  timeout 60 bash -c 'until docker compose exec -T db mysqladmin ping -h"localhost" -u"root" -p"password" --silent; do sleep 2; done'
                   timeout 60 bash -c 'until curl -f http://localhost:8080 >/dev/null 2>&1; do sleep 2; done'
 
             - name: Validate test environment
@@ -61,7 +52,7 @@ jobs:
 
             - name: Stop services
               if: always()
-              run: docker-compose down
+              run: docker compose down
 
     # Unit Tests
     unit-tests:
@@ -72,14 +63,6 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
 
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
-
-            - name: Install Docker Compose
-              run: |
-                  sudo curl -L "https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-                  sudo chmod +x /usr/local/bin/docker-compose
-
             - name: Set up Node.js
               uses: actions/setup-node@v4
               with:
@@ -94,17 +77,17 @@ jobs:
 
             - name: Start Docker services
               run: |
-                  docker-compose up -d db
-                  docker-compose up -d wordpress
+                  docker compose up -d db
+                  docker compose up -d wordpress
 
             - name: Wait for services to be ready
               run: |
-                  timeout 60 bash -c 'until docker-compose exec -T db mysqladmin ping -h"localhost" -u"root" -p"password" --silent; do sleep 2; done'
+                  timeout 60 bash -c 'until docker compose exec -T db mysqladmin ping -h"localhost" -u"root" -p"password" --silent; do sleep 2; done'
                   timeout 60 bash -c 'until curl -f http://localhost:8080 >/dev/null 2>&1; do sleep 2; done'
 
             - name: Run unit tests
               run: |
-                  docker-compose run --rm test ci --coverage-enabled --generate-reports --coverage-dir coverage --test-reports-dir test-reports
+                  docker compose run --rm test ci --coverage-enabled --generate-reports --coverage-dir coverage --test-reports-dir test-reports
 
             - name: Upload test results
               uses: actions/upload-artifact@v4
@@ -118,7 +101,7 @@ jobs:
 
             - name: Stop services
               if: always()
-              run: docker-compose down
+              run: docker compose down
 
     # Coverage Analysis
     coverage-analysis:
@@ -128,14 +111,6 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
-
-            - name: Install Docker Compose
-              run: |
-                  sudo curl -L "https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-                  sudo chmod +x /usr/local/bin/docker-compose
 
             - name: Set up Node.js
               uses: actions/setup-node@v4
@@ -151,17 +126,17 @@ jobs:
 
             - name: Start Docker services
               run: |
-                  docker-compose up -d db
-                  docker-compose up -d wordpress
+                  docker compose up -d db
+                  docker compose up -d wordpress
 
             - name: Wait for services to be ready
               run: |
-                  timeout 60 bash -c 'until docker-compose exec -T db mysqladmin ping -h"localhost" -u"root" -p"password" --silent; do sleep 2; done'
+                  timeout 60 bash -c 'until docker compose exec -T db mysqladmin ping -h"localhost" -u"root" -p"password" --silent; do sleep 2; done'
                   timeout 60 bash -c 'until curl -f http://localhost:8080 >/dev/null 2>&1; do sleep 2; done'
 
             - name: Run coverage analysis
               run: |
-                  docker-compose run --rm test ci --coverage-enabled --generate-reports --coverage-dir coverage --test-reports-dir test-reports
+                  docker compose run --rm test ci --coverage-enabled --generate-reports --coverage-dir coverage --test-reports-dir test-reports
 
             - name: Check coverage thresholds
               run: |
@@ -196,7 +171,7 @@ jobs:
 
             - name: Stop services
               if: always()
-              run: docker-compose down
+              run: docker compose down
 
     # Performance Testing
     performance-tests:
@@ -206,14 +181,6 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
-
-            - name: Install Docker Compose
-              run: |
-                  sudo curl -L "https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-                  sudo chmod +x /usr/local/bin/docker-compose
 
             - name: Set up Node.js
               uses: actions/setup-node@v4
@@ -229,12 +196,12 @@ jobs:
 
             - name: Start Docker services
               run: |
-                  docker-compose up -d db
-                  docker-compose up -d wordpress
+                  docker compose up -d db
+                  docker compose up -d wordpress
 
             - name: Wait for services to be ready
               run: |
-                  timeout 60 bash -c 'until docker-compose exec -T db mysqladmin ping -h"localhost" -u"root" -p"password" --silent; do sleep 2; done'
+                  timeout 60 bash -c 'until docker compose exec -T db mysqladmin ping -h"localhost" -u"root" -p"password" --silent; do sleep 2; done'
                   timeout 60 bash -c 'until curl -f http://localhost:8080 >/dev/null 2>&1; do sleep 2; done'
 
             - name: Run performance benchmarks
@@ -266,7 +233,7 @@ jobs:
 
             - name: Stop services
               if: always()
-              run: docker-compose down
+              run: docker compose down
 
     # Integration Tests
     integration-tests:
@@ -276,14 +243,6 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
-
-            - name: Install Docker Compose
-              run: |
-                  sudo curl -L "https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-                  sudo chmod +x /usr/local/bin/docker-compose
 
             - name: Set up Node.js
               uses: actions/setup-node@v4
@@ -299,17 +258,17 @@ jobs:
 
             - name: Start Docker services
               run: |
-                  docker-compose up -d db
-                  docker-compose up -d wordpress
+                  docker compose up -d db
+                  docker compose up -d wordpress
 
             - name: Wait for services to be ready
               run: |
-                  timeout 60 bash -c 'until docker-compose exec -T db mysqladmin ping -h"localhost" -u"root" -p"password" --silent; do sleep 2; done'
+                  timeout 60 bash -c 'until docker compose exec -T db mysqladmin ping -h"localhost" -u"root" -p"password" --silent; do sleep 2; done'
                   timeout 60 bash -c 'until curl -f http://localhost:8080 >/dev/null 2>&1; do sleep 2; done'
 
             - name: Run integration tests
               run: |
-                  docker-compose run --rm test ci --coverage-enabled --generate-reports --coverage-dir coverage --test-reports-dir test-reports
+                  docker compose run --rm test ci --coverage-enabled --generate-reports --coverage-dir coverage --test-reports-dir test-reports
 
             - name: Upload integration test results
               uses: actions/upload-artifact@v4
@@ -323,7 +282,7 @@ jobs:
 
             - name: Stop services
               if: always()
-              run: docker-compose down
+              run: docker compose down
 
     # Security Tests
     security-tests:
@@ -333,14 +292,6 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
-
-            - name: Install Docker Compose
-              run: |
-                  sudo curl -L "https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-                  sudo chmod +x /usr/local/bin/docker-compose
 
             - name: Set up Node.js
               uses: actions/setup-node@v4
@@ -356,17 +307,17 @@ jobs:
 
             - name: Start Docker services
               run: |
-                  docker-compose up -d db
-                  docker-compose up -d wordpress
+                  docker compose up -d db
+                  docker compose up -d wordpress
 
             - name: Wait for services to be ready
               run: |
-                  timeout 60 bash -c 'until docker-compose exec -T db mysqladmin ping -h"localhost" -u"root" -p"password" --silent; do sleep 2; done'
+                  timeout 60 bash -c 'until docker compose exec -T db mysqladmin ping -h"localhost" -u"root" -p"password" --silent; do sleep 2; done'
                   timeout 60 bash -c 'until curl -f http://localhost:8080 >/dev/null 2>&1; do sleep 2; done'
 
             - name: Run security tests
               run: |
-                  docker-compose run --rm test ci --coverage-enabled --generate-reports --coverage-dir coverage --test-reports-dir test-reports
+                  docker compose run --rm test ci --coverage-enabled --generate-reports --coverage-dir coverage --test-reports-dir test-reports
 
             - name: Upload security test results
               uses: actions/upload-artifact@v4
@@ -379,7 +330,7 @@ jobs:
 
             - name: Stop services
               if: always()
-              run: docker-compose down
+              run: docker compose down
 
     # Test Summary and Reporting
     test-summary:
@@ -480,7 +431,7 @@ jobs:
     # Build and Deploy (only on main branch)
     build-and-deploy:
         name: Build and Deploy
-    runs-on: ubuntu-latest
+        runs-on: ubuntu-latest
         needs:
             [
                 unit-tests,
@@ -495,9 +446,9 @@ jobs:
             SSH_USER: ${{ secrets.SSH_USER }}
             SSH_KEY: ${{ secrets.SSH_KEY }}
             DEST_PATH: ${{ secrets.DEST_PATH }}
-    steps:
+        steps:
             - name: Checkout code
-        uses: actions/checkout@v4
+              uses: actions/checkout@v4
 
             - name: Set up Node.js
               uses: actions/setup-node@v4
@@ -511,22 +462,22 @@ jobs:
             - name: Build project
               run: npm run build
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
                   php-version: ${{ env.PHP_VERSION }}
-          tools: phpunit-polyfills:1.1
+                  tools: phpunit-polyfills:1.1
 
             - name: Install PHP dependencies
-        run: |
-            cd power-of-families
+              run: |
+                  cd power-of-families
                   composer install --no-dev
-            composer dump-autoload --optimize
+                  composer dump-autoload --optimize
 
             - name: Rsync to remote host
               env:
                   SSH_KEY: ${{ secrets.SSH_KEY }}
-        run: |
+              run: |
                   mkdir -p ~/.ssh
                   echo "$SSH_KEY" > ~/.ssh/id_rsa
                   chmod 600 ~/.ssh/id_rsa


### PR DESCRIPTION
## Summary
- Replaced `docker-compose` (v1 standalone) with `docker compose` (v2 plugin) in deploy and testing workflows — v2 is pre-installed on GitHub Actions runners
- Removed the "Install Docker Compose" steps that were downloading a broken URL (missing `v` prefix caused 404)
- Fixed broken YAML indentation in testing.yml's `build-and-deploy` job and `on:` trigger block

## Test plan
- [ ] Verify the "Deploy via SSH" workflow passes on this branch
- [ ] Verify the "Docker-Based Testing" workflow parses correctly and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)