### PR TITLE
Harden install-wp-tests.sh against transient download failures

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -19,9 +19,9 @@ WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress}
 
 download() {
     if [ `which curl` ]; then
-        curl -s "$1" > "$2";
+        curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 10 --max-time 300 -o "$2" "$1"
     elif [ `which wget` ]; then
-        wget -nv -O "$2" "$1"
+        wget --tries=3 --timeout=60 --waitretry=5 -nv -O "$2" "$1"
     else
         echo "Error: Neither curl nor wget is installed."
         exit 1

--- a/install-wp-tests.sh
+++ b/install-wp-tests.sh
@@ -19,9 +19,9 @@ WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress}
 
 download() {
     if [ `which curl` ]; then
-        curl -s "$1" > "$2";
+        curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 10 --max-time 300 -o "$2" "$1"
     elif [ `which wget` ]; then
-        wget -nv -O "$2" "$1"
+        wget --tries=3 --timeout=60 --waitretry=5 -nv -O "$2" "$1"
     else
         echo "Error: Neither curl nor wget is installed."
         exit 1


### PR DESCRIPTION
## Summary

The `download()` helper in both copies of `install-wp-tests.sh` previously ran `curl -s "$1" > "$2"` with no timeouts, retries, or HTTP-error handling. A stalled fetch of `https://wordpress.org/latest.tar.gz` (the symptom seen in #30) would hang until the CI runner's job timeout killed it (curl exit 28), and an HTTP 4xx/5xx would silently write an HTML error page into `$2` instead of failing.

This PR adds retry, timeout, and fail-on-error flags to both `curl` and `wget`:

- `curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 10 --max-time 300 -o "$2" "$1"`
  - `-f` — fail loudly on HTTP 4xx/5xx instead of silently writing the error body
  - `-S` — keep error messages visible alongside `-s`
  - `-L` — follow redirects (wordpress.org redirects in some regions)
  - `--retry 3 --retry-delay 5 --retry-all-errors` — retry transient *and* HTTP errors
  - `--connect-timeout 10 --max-time 300` — bound stalls
- `wget --tries=3 --timeout=60 --waitretry=5 -nv -O "$2" "$1"`

Applied identically to `install-wp-tests.sh` and `bin/install-wp-tests.sh`.

## Note on the two copies

I checked whether the two scripts could be deduped via symlink, but they're **not** byte-identical outside the `download()` function — `bin/install-wp-tests.sh` adds extra debug `echo`s, passes `--ssl=0` to `mysqladmin`/`mysql`, and skips the interactive "are you sure" prompt when the test DB already exists. So they're kept separate, and this PR updates both in lockstep. Consolidating them is out of scope here.

## Test plan

- [x] Success path: `curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 10 --max-time 300 -o /tmp/wp.tar.gz https://wordpress.org/latest.tar.gz` → exit 0, valid 27 MB gzip.
- [x] Failure path: same flags against `https://wordpress.org/nonexistent.tar.gz` → curl retries 3 times, exits 56, **no** garbage file written (vs. the old behavior which wrote the HTML 404 body to `$2`).
- [ ] CI green on this branch.

Refs: original CI flake observed in #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)