### PR TITLE
Fix CI: use docker compose V2 in bin scripts

### DIFF
--- a/bin/manage-test-db.sh
+++ b/bin/manage-test-db.sh
@@ -203,7 +203,7 @@ handle_status() {
     log_info "Checking test database status..."
     
     # Check if database is running
-    if docker-compose ps db | grep -q "Up"; then
+    if docker compose ps db | grep -q "Up"; then
         log_success "Database container is running"
     else
         log_warning "Database container is not running"
@@ -222,7 +222,7 @@ handle_status() {
     fi
     
     # Check if test container exists
-    if docker-compose ps test | grep -q "Up"; then
+    if docker compose ps test | grep -q "Up"; then
         log_success "Test container is running"
     elif docker images | grep -q "power-of-families_test"; then
         log_info "Test container image exists but is not running"

--- a/bin/reset-test-db.sh
+++ b/bin/reset-test-db.sh
@@ -26,7 +26,7 @@ bash bin/cleanup-test-db.sh
 
 # Step 2: Stop and restart database container
 echo -e "${YELLOW}📋 Step 2: Restarting database container...${NC}"
-docker-compose restart db
+docker compose restart db
 
 # Wait for database to be ready
 echo -e "${YELLOW}⏳ Waiting for database to be ready...${NC}"
@@ -44,11 +44,11 @@ echo -e "${YELLOW}📋 Step 4: Cleaning up Docker environment...${NC}"
 
 # Stop test containers
 echo -e "${YELLOW}   Stopping test containers...${NC}"
-docker-compose stop test 2>/dev/null || true
+docker compose stop test 2>/dev/null || true
 
 # Remove test containers
 echo -e "${YELLOW}   Removing test containers...${NC}"
-docker-compose rm -f test 2>/dev/null || true
+docker compose rm -f test 2>/dev/null || true
 
 # Clean up unused Docker resources
 echo -e "${YELLOW}   Cleaning up unused Docker resources...${NC}"
@@ -56,7 +56,7 @@ docker system prune -f --volumes 2>/dev/null || true
 
 # Step 5: Rebuild test container
 echo -e "${YELLOW}📋 Step 5: Rebuilding test container...${NC}"
-docker-compose build test
+docker compose build test
 
 # Step 6: Verify test environment
 echo -e "${YELLOW}📋 Step 6: Verifying test environment...${NC}"
@@ -73,7 +73,7 @@ fi
 
 # Test container build
 echo -e "${YELLOW}   Testing container build...${NC}"
-docker-compose run --rm test php --version > /dev/null 2>&1
+docker compose run --rm test php --version > /dev/null 2>&1
 if [ $? -eq 0 ]; then
     echo -e "${GREEN}   ✅ Test container working${NC}"
 else
@@ -83,7 +83,7 @@ fi
 
 # Step 7: Run basic test to verify everything works
 echo -e "${YELLOW}📋 Step 7: Running basic test verification...${NC}"
-if docker-compose run --rm test phpunit --version > /dev/null 2>&1; then
+if docker compose run --rm test phpunit --version > /dev/null 2>&1; then
     echo -e "${GREEN}   ✅ PHPUnit available${NC}"
 else
     echo -e "${RED}   ❌ PHPUnit not available${NC}"
@@ -99,5 +99,5 @@ echo -e "   Verification: ${GREEN}Passed${NC}"
 echo ""
 echo -e "${BLUE}💡 Next steps:${NC}"
 echo -e "   Run tests: ${GREEN}npm run test:php${NC}"
-echo -e "   Debug tests: ${GREEN}docker-compose run --rm test --mode debug${NC}"
-echo -e "   Coverage: ${GREEN}docker-compose run --rm test --mode coverage${NC}"
+echo -e "   Debug tests: ${GREEN}docker compose run --rm test --mode debug${NC}"
+echo -e "   Coverage: ${GREEN}docker compose run --rm test --mode coverage${NC}"

--- a/bin/run-tests-ci.sh
+++ b/bin/run-tests-ci.sh
@@ -178,7 +178,7 @@ execute_ci_tests() {
     log_info "Executing tests for CI/CD..."
     
     # Use the container's built-in test execution with coverage enabled
-    local phpunit_cmd="docker-compose run --rm test ci"
+    local phpunit_cmd="docker compose run --rm test ci"
     phpunit_cmd="$phpunit_cmd --coverage-enabled"
     phpunit_cmd="$phpunit_cmd --generate-reports"
     phpunit_cmd="$phpunit_cmd --coverage-dir $COVERAGE_DIR"

--- a/bin/run-tests-quick.sh
+++ b/bin/run-tests-quick.sh
@@ -78,7 +78,7 @@ log_error() {
 
 # Build PHPUnit command
 build_phpunit_command() {
-    local phpunit_cmd="docker-compose run --rm test phpunit --configuration phpunit.xml"
+    local phpunit_cmd="docker compose run --rm test phpunit --configuration phpunit.xml"
     
     # Add test filter
     if [ -n "$TEST_FILTER" ]; then

--- a/bin/run-tests-with-reporting.sh
+++ b/bin/run-tests-with-reporting.sh
@@ -217,7 +217,7 @@ initialize_test_environment() {
 
 # Build PHPUnit command
 build_phpunit_command() {
-    local phpunit_cmd="docker-compose run --rm test"
+    local phpunit_cmd="docker compose run --rm test"
     
     # Add memory limit
     phpunit_cmd="$phpunit_cmd php -d memory_limit=$MEMORY_LIMIT"

--- a/bin/seed-test-db.sh
+++ b/bin/seed-test-db.sh
@@ -229,7 +229,7 @@ try {
 EOF
 
     # Run the seeding script
-    if docker-compose run --rm test php /tmp/seed-database.php; then
+    if docker compose run --rm test php /tmp/seed-database.php; then
         log_success "Database seeded successfully"
     else
         log_error "Database seeding failed"
@@ -301,7 +301,7 @@ if ($errors > 0) {
 }
 EOF
 
-    if docker-compose run --rm test php /tmp/verify-data.php; then
+    if docker compose run --rm test php /tmp/verify-data.php; then
         log_success "Data integrity verified"
     else
         log_error "Data integrity verification failed"
@@ -385,7 +385,7 @@ main() {
     echo ""
     echo -e "${BLUE}💡 Next steps:${NC}"
     echo -e "  Run tests: ${GREEN}npm run test:php${NC}"
-    echo -e "  Check data: ${GREEN}docker-compose run --rm test wp-cli post list${NC}"
+    echo -e "  Check data: ${GREEN}docker compose run --rm test wp-cli post list${NC}"
     echo -e "  Clean up: ${GREEN}bash bin/cleanup-test-db.sh${NC}"
 }
 

--- a/bin/test-debug-profile.sh
+++ b/bin/test-debug-profile.sh
@@ -145,7 +145,7 @@ log_verbose() {
 
 # Build PHPUnit command with debugging
 build_debug_command() {
-    local phpunit_cmd="docker-compose run --rm"
+    local phpunit_cmd="docker compose run --rm"
     phpunit_cmd="$phpunit_cmd -e XDEBUG_MODE=debug"
     phpunit_cmd="$phpunit_cmd -e XDEBUG_CONFIG=client_host=$DEBUG_HOST client_port=$DEBUG_PORT idekey=docker"
     phpunit_cmd="$phpunit_cmd -e XDEBUG_START_WITH_REQUEST=yes"
@@ -166,7 +166,7 @@ build_debug_command() {
 
 # Build PHPUnit command with profiling
 build_profile_command() {
-    local phpunit_cmd="docker-compose run --rm"
+    local phpunit_cmd="docker compose run --rm"
     phpunit_cmd="$phpunit_cmd -e XDEBUG_MODE=profile"
     phpunit_cmd="$phpunit_cmd -e XDEBUG_OUTPUT_DIR=$PROFILE_OUTPUT_DIR"
     phpunit_cmd="$phpunit_cmd -e XDEBUG_PROFILER_ENABLE=1"
@@ -187,7 +187,7 @@ build_profile_command() {
 
 # Build PHPUnit command with coverage
 build_coverage_command() {
-    local phpunit_cmd="docker-compose run --rm"
+    local phpunit_cmd="docker compose run --rm"
     phpunit_cmd="$phpunit_cmd -e XDEBUG_MODE=coverage"
     phpunit_cmd="$phpunit_cmd test"
     phpunit_cmd="$phpunit_cmd php -d memory_limit=$MEMORY_LIMIT"
@@ -425,7 +425,7 @@ setup_debug_environment() {
     mkdir -p "$PROFILE_OUTPUT_DIR"
     
     # Check if xDebug is available
-    if docker-compose run --rm test php -m | grep -q xdebug; then
+    if docker compose run --rm test php -m | grep -q xdebug; then
         log_success "xDebug extension is available"
     else
         log_error "xDebug extension is not available"
@@ -434,7 +434,7 @@ setup_debug_environment() {
     
     # Test debug connection
     log_info "Testing debug connection..."
-    if docker-compose run --rm test php -r "
+    if docker compose run --rm test php -r "
         if (function_exists('xdebug_info')) {
             echo 'xDebug is properly configured' . PHP_EOL;
         } else {
@@ -457,7 +457,7 @@ setup_profile_environment() {
     mkdir -p "$PROFILE_OUTPUT_DIR"
     
     # Check if xDebug is available
-    if docker-compose run --rm test php -m | grep -q xdebug; then
+    if docker compose run --rm test php -m | grep -q xdebug; then
         log_success "xDebug extension is available"
     else
         log_error "xDebug extension is not available"
@@ -466,7 +466,7 @@ setup_profile_environment() {
     
     # Test profile configuration
     log_info "Testing profile configuration..."
-    if docker-compose run --rm test php -r "
+    if docker compose run --rm test php -r "
         if (ini_get('xdebug.mode') && strpos(ini_get('xdebug.mode'), 'profile') !== false) {
             echo 'Profile mode is properly configured' . PHP_EOL;
         } else {

--- a/bin/test-dev-helper.sh
+++ b/bin/test-dev-helper.sh
@@ -489,7 +489,7 @@ generate_test_data() {
     log_info "Generating test data for development..."
     
     # Run the enhanced test data seeder
-    if docker-compose run --rm test php -r "
+    if docker compose run --rm test php -r "
         require_once '/tmp/wordpress-tests-lib/includes/functions.php';
         require_once dirname(__DIR__) . '/wp-content/themes/power-of-families/functions.php';
         require_once dirname(__DIR__) . '/wp-content/themes/power-of-families/tests/seeders/EnhancedTestDataSeeder.php';
@@ -540,7 +540,7 @@ show_file_coverage() {
     log_info "Showing coverage for: $file_path"
     
     # Run coverage analysis for specific file
-    if docker-compose run --rm test phpunit --configuration phpunit.xml --coverage-text --filter "$file_path"; then
+    if docker compose run --rm test phpunit --configuration phpunit.xml --coverage-text --filter "$file_path"; then
         log_success "Coverage analysis completed"
     else
         log_error "Coverage analysis failed"
@@ -555,7 +555,7 @@ run_performance_tests() {
     local start_time=$(date +%s)
     
     # Run tests with performance monitoring
-    if docker-compose run --rm test phpunit --configuration phpunit.xml --verbose; then
+    if docker compose run --rm test phpunit --configuration phpunit.xml --verbose; then
         local end_time=$(date +%s)
         local duration=$((end_time - start_time))
         
@@ -572,7 +572,7 @@ run_memory_tests() {
     log_info "Running memory usage tests..."
     
     # Run tests with memory monitoring
-    if docker-compose run --rm test php -d memory_limit=2G phpunit --configuration phpunit.xml --verbose; then
+    if docker compose run --rm test php -d memory_limit=2G phpunit --configuration phpunit.xml --verbose; then
         log_success "Memory tests completed"
         log_info "Check test output for memory usage information"
     else

--- a/bin/test-docs.sh
+++ b/bin/test-docs.sh
@@ -316,7 +316,7 @@ show_troubleshooting() {
     echo "   Problem: Tests fail to execute"
     echo "   Solution:"
     echo "   • Check Docker is running: docker info"
-    echo "   • Verify test container: docker-compose ps test"
+    echo "   • Verify test container: docker compose ps test"
     echo "   • Check test environment: bin/test-env-manager.sh status"
     echo ""
     
@@ -504,7 +504,7 @@ show_environment_setup() {
     echo "   cd wp-content/themes/power-of-families"
     echo ""
     echo -e "${CYAN}2. Start Docker Services${NC}"
-    echo "   docker-compose up -d"
+    echo "   docker compose up -d"
     echo ""
     echo -e "${CYAN}3. Setup Test Environment${NC}"
     echo "   bin/test-env-manager.sh setup"
@@ -534,7 +534,7 @@ show_environment_setup() {
     
     echo -e "${YELLOW}Troubleshooting Setup:${NC}"
     echo "• Check Docker status: docker info"
-    echo "• Check container status: docker-compose ps"
+    echo "• Check container status: docker compose ps"
     echo "• Check environment: bin/test-env-manager.sh status"
     echo "• Validate setup: bin/test-env-manager.sh validate"
     echo ""

--- a/bin/test-env-manager.sh
+++ b/bin/test-env-manager.sh
@@ -160,16 +160,16 @@ check_docker() {
     return 0
 }
 
-# Check if docker-compose is available
+# Check if docker compose is available
 check_docker_compose() {
-    log_verbose "Checking docker-compose availability..."
+    log_verbose "Checking docker compose availability..."
     
-    if ! command -v docker-compose >/dev/null 2>&1; then
-        log_error "docker-compose is not available"
+    if ! docker compose version >/dev/null 2>&1; then
+        log_error "docker compose is not available"
         return 1
     fi
     
-    log_success "docker-compose is available"
+    log_success "docker compose is available"
     return 0
 }
 
@@ -177,7 +177,7 @@ check_docker_compose() {
 check_test_container() {
     log_verbose "Checking test container..."
     
-    if docker-compose ps test >/dev/null 2>&1; then
+    if docker compose ps test >/dev/null 2>&1; then
         log_success "Test container is configured"
         return 0
     else
@@ -190,7 +190,7 @@ check_test_container() {
 check_test_database() {
     log_verbose "Checking test database..."
     
-    if docker-compose exec -T db mysqladmin ping -h"localhost" -u"root" -p"password" --silent 2>/dev/null; then
+    if docker compose exec -T db mysqladmin ping -h"localhost" -u"root" -p"password" --silent 2>/dev/null; then
         log_success "Test database is accessible"
         return 0
     else
@@ -273,7 +273,7 @@ setup_test_environment() {
     
     # Build test container
     log_info "Building test container..."
-    if docker-compose build test; then
+    if docker compose build test; then
         log_success "Test container built"
     else
         log_error "Failed to build test container"
@@ -317,8 +317,8 @@ teardown_test_environment() {
     
     # Stop test containers
     log_info "Stopping test containers..."
-    docker-compose stop test 2>/dev/null || true
-    docker-compose stop db 2>/dev/null || true
+    docker compose stop test 2>/dev/null || true
+    docker compose stop db 2>/dev/null || true
     
     log_success "Test containers stopped"
     
@@ -415,7 +415,7 @@ validate_environment() {
         validation_passed=false
     fi
     
-    # Check docker-compose
+    # Check docker compose
     if ! check_docker_compose; then
         validation_passed=false
     fi

--- a/bin/test-interactive.sh
+++ b/bin/test-interactive.sh
@@ -156,7 +156,7 @@ display_status() {
 
 # Build PHPUnit command
 build_phpunit_command() {
-    local phpunit_cmd="docker-compose run --rm test"
+    local phpunit_cmd="docker compose run --rm test"
     
     # Set environment variables
     local env_vars=""

--- a/bin/test-performance-monitor.sh
+++ b/bin/test-performance-monitor.sh
@@ -140,7 +140,7 @@ monitor_performance() {
     
     # Start test execution in background
     log_info "Starting test execution..."
-    docker-compose run --rm test php -d memory_limit="$MEMORY_LIMIT" phpunit --configuration phpunit.xml --verbose > "$metrics_file" 2>&1 &
+    docker compose run --rm test php -d memory_limit="$MEMORY_LIMIT" phpunit --configuration phpunit.xml --verbose > "$metrics_file" 2>&1 &
     local test_pid=$!
     
     # Monitor performance
@@ -251,7 +251,7 @@ run_benchmarks() {
         local start_memory=$(free -m | grep Mem | awk '{print $3}')
         
         # Run tests
-        if docker-compose run --rm test php -d memory_limit="$MEMORY_LIMIT" phpunit --configuration phpunit.xml >/dev/null 2>&1; then
+        if docker compose run --rm test php -d memory_limit="$MEMORY_LIMIT" phpunit --configuration phpunit.xml >/dev/null 2>&1; then
             local end_time=$(date +%s.%N)
             local end_memory=$(free -m | grep Mem | awk '{print $3}')
             
@@ -305,7 +305,7 @@ test_memory_usage() {
     
     log_info "Running tests with memory monitoring..."
     
-    if docker-compose run --rm test php -d memory_limit="$MEMORY_LIMIT" phpunit --configuration phpunit.xml --verbose 2>&1 | tee "$memory_log"; then
+    if docker compose run --rm test php -d memory_limit="$MEMORY_LIMIT" phpunit --configuration phpunit.xml --verbose 2>&1 | tee "$memory_log"; then
         log_success "Memory usage test completed"
         
         # Analyze memory usage
@@ -351,7 +351,7 @@ test_cpu_usage() {
     local monitor_pid=$!
     
     # Run tests
-    if docker-compose run --rm test php -d memory_limit="$MEMORY_LIMIT" phpunit --configuration phpunit.xml >/dev/null 2>&1; then
+    if docker compose run --rm test php -d memory_limit="$MEMORY_LIMIT" phpunit --configuration phpunit.xml >/dev/null 2>&1; then
         # Stop monitoring
         kill $monitor_pid 2>/dev/null || true
         wait $monitor_pid 2>/dev/null || true
@@ -395,7 +395,7 @@ identify_slow_tests() {
     
     log_info "Running tests with timing analysis..."
     
-    if docker-compose run --rm test php -d memory_limit="$MEMORY_LIMIT" phpunit --configuration phpunit.xml --verbose 2>&1 | tee "$timing_log"; then
+    if docker compose run --rm test php -d memory_limit="$MEMORY_LIMIT" phpunit --configuration phpunit.xml --verbose 2>&1 | tee "$timing_log"; then
         log_success "Slow test analysis completed"
         
         # Extract slow tests
@@ -446,7 +446,7 @@ check_memory_leaks() {
         local start_memory=$(free -m | grep Mem | awk '{print $3}')
         
         # Run tests
-        if docker-compose run --rm test php -d memory_limit="$MEMORY_LIMIT" phpunit --configuration phpunit.xml >/dev/null 2>&1; then
+        if docker compose run --rm test php -d memory_limit="$MEMORY_LIMIT" phpunit --configuration phpunit.xml >/dev/null 2>&1; then
             local end_memory=$(free -m | grep Mem | awk '{print $3}')
             local memory_diff=$((end_memory - start_memory))
             
@@ -487,9 +487,9 @@ generate_performance_report() {
     local report_file="${OUTPUT_FILE:-test-performance-report-$(date +%Y%m%d-%H%M%S).html}"
     
     # Collect performance data
-    local total_tests=$(docker-compose run --rm test phpunit --configuration phpunit.xml 2>&1 | grep -o "Tests: [0-9]*" | tail -1 | grep -o "[0-9]*" || echo "0")
-    local total_time=$(docker-compose run --rm test phpunit --configuration phpunit.xml 2>&1 | grep -o "Time: [0-9.]*" | tail -1 | grep -o "[0-9.]*" || echo "0")
-    local peak_memory=$(docker-compose run --rm test phpunit --configuration phpunit.xml 2>&1 | grep -o "Peak memory: [0-9.]*" | tail -1 | grep -o "[0-9.]*" || echo "0")
+    local total_tests=$(docker compose run --rm test phpunit --configuration phpunit.xml 2>&1 | grep -o "Tests: [0-9]*" | tail -1 | grep -o "[0-9]*" || echo "0")
+    local total_time=$(docker compose run --rm test phpunit --configuration phpunit.xml 2>&1 | grep -o "Time: [0-9.]*" | tail -1 | grep -o "[0-9.]*" || echo "0")
+    local peak_memory=$(docker compose run --rm test phpunit --configuration phpunit.xml 2>&1 | grep -o "Peak memory: [0-9.]*" | tail -1 | grep -o "[0-9.]*" || echo "0")
     
     # Generate HTML report
     cat > "$report_file" << EOF
@@ -563,8 +563,8 @@ suggest_optimizations() {
     echo ""
     
     # Run basic performance analysis
-    local total_tests=$(docker-compose run --rm test phpunit --configuration phpunit.xml 2>&1 | grep -o "Tests: [0-9]*" | tail -1 | grep -o "[0-9]*" || echo "0")
-    local total_time=$(docker-compose run --rm test phpunit --configuration phpunit.xml 2>&1 | grep -o "Time: [0-9.]*" | tail -1 | grep -o "[0-9.]*" || echo "0")
+    local total_tests=$(docker compose run --rm test phpunit --configuration phpunit.xml 2>&1 | grep -o "Tests: [0-9]*" | tail -1 | grep -o "[0-9]*" || echo "0")
+    local total_time=$(docker compose run --rm test phpunit --configuration phpunit.xml 2>&1 | grep -o "Time: [0-9.]*" | tail -1 | grep -o "[0-9.]*" || echo "0")
     
     echo -e "${WHITE}💡 Performance Optimization Suggestions${NC}"
     echo "====================================="

--- a/bin/test-xdebug.sh
+++ b/bin/test-xdebug.sh
@@ -9,7 +9,7 @@ echo "🔍 Testing xDebug configuration in WordPress container..."
 
 # Check if xDebug is loaded
 echo "📋 Checking if xDebug extension is loaded..."
-docker-compose exec wordpress php -m | grep -i xdebug || {
+docker compose exec wordpress php -m | grep -i xdebug || {
     echo "❌ xDebug extension not found!"
     exit 1
 }
@@ -18,7 +18,7 @@ echo "✅ xDebug extension is loaded"
 
 # Check xDebug configuration
 echo "📋 Checking xDebug configuration..."
-docker-compose exec wordpress php -r "
+docker compose exec wordpress php -r "
 \$config = ini_get_all('xdebug');
 echo 'xDebug Configuration:' . PHP_EOL;
 echo 'Mode: ' . (\$config['xdebug.mode']['global_value'] ?? 'not set') . PHP_EOL;
@@ -30,7 +30,7 @@ echo 'Log Level: ' . (\$config['xdebug.log_level']['global_value'] ?? 'not set')
 
 # Test xDebug functions
 echo "📋 Testing xDebug functions..."
-docker-compose exec wordpress php -r "
+docker compose exec wordpress php -r "
 if (function_exists('xdebug_info')) {
     echo '✅ xdebug_info() function available' . PHP_EOL;
 } else {
@@ -46,7 +46,7 @@ if (function_exists('xdebug_break')) {
 
 # Check if profiling is enabled
 echo "📋 Checking profiling configuration..."
-docker-compose exec wordpress php -r "
+docker compose exec wordpress php -r "
 \$profiler_enabled = ini_get('xdebug.profiler_enable');
 \$profiler_trigger = ini_get('xdebug.profiler_enable_trigger');
 echo 'Profiler enabled: ' . (\$profiler_enabled ? 'Yes' : 'No') . PHP_EOL;
@@ -55,7 +55,7 @@ echo 'Profiler trigger: ' . (\$profiler_trigger ? 'Yes' : 'No') . PHP_EOL;
 
 # Test coverage functionality
 echo "📋 Testing coverage functionality..."
-docker-compose exec wordpress php -r "
+docker compose exec wordpress php -r "
 if (function_exists('xdebug_start_code_coverage')) {
     echo '✅ Code coverage functions available' . PHP_EOL;
     xdebug_start_code_coverage(XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE);

--- a/bin/verify-db-isolation.sh
+++ b/bin/verify-db-isolation.sh
@@ -23,7 +23,7 @@ echo -e "${BLUE}🔍 Verifying database isolation...${NC}"
 
 # Wait for database to be ready
 echo -e "${YELLOW}⏳ Waiting for database to be ready...${NC}"
-until docker-compose exec -T db mysqladmin ping -h"localhost" -u"$TEST_DB_USER" -p"$TEST_DB_PASSWORD" --silent 2>/dev/null; do
+until docker compose exec -T db mysqladmin ping -h"localhost" -u"$TEST_DB_USER" -p"$TEST_DB_PASSWORD" --silent 2>/dev/null; do
     echo -e "${YELLOW}   Waiting for database...${NC}"
     sleep 2
 done
@@ -34,7 +34,7 @@ echo -e "${GREEN}✅ Database connection established${NC}"
 echo -e "${YELLOW}📊 Checking database existence...${NC}"
 
 # Check test database
-if docker-compose exec -T db mysql -u"$TEST_DB_USER" -p"$TEST_DB_PASSWORD" -e "USE \`$TEST_DB_NAME\`;" 2>/dev/null; then
+if docker compose exec -T db mysql -u"$TEST_DB_USER" -p"$TEST_DB_PASSWORD" -e "USE \`$TEST_DB_NAME\`;" 2>/dev/null; then
     echo -e "${GREEN}   ✅ Test database ($TEST_DB_NAME) exists${NC}"
 else
     echo -e "${RED}   ❌ Test database ($TEST_DB_NAME) does not exist${NC}"
@@ -42,7 +42,7 @@ else
 fi
 
 # Check development database
-if docker-compose exec -T db mysql -u"$TEST_DB_USER" -p"$TEST_DB_PASSWORD" -e "USE \`$DEV_DB_NAME\`;" 2>/dev/null; then
+if docker compose exec -T db mysql -u"$TEST_DB_USER" -p"$TEST_DB_PASSWORD" -e "USE \`$DEV_DB_NAME\`;" 2>/dev/null; then
     echo -e "${GREEN}   ✅ Development database ($DEV_DB_NAME) exists${NC}"
 else
     echo -e "${YELLOW}   ⚠️  Development database ($DEV_DB_NAME) does not exist (this is OK for testing)${NC}"

--- a/bin/verify-test-isolation.sh
+++ b/bin/verify-test-isolation.sh
@@ -130,7 +130,7 @@ log_verbose() {
 # Wait for database to be ready
 wait_for_database() {
     log_info "Waiting for database to be ready..."
-    until docker-compose exec -T db mysqladmin ping -h"localhost" -u"$TEST_DB_USER" -p"$TEST_DB_PASSWORD" --silent 2>/dev/null; do
+    until docker compose exec -T db mysqladmin ping -h"localhost" -u"$TEST_DB_USER" -p"$TEST_DB_PASSWORD" --silent 2>/dev/null; do
         log_verbose "   Waiting for database..."
         sleep 2
     done
@@ -256,7 +256,7 @@ try {
 EOF
 
     # Run the verification script
-    if docker-compose run --rm test php /tmp/verify-isolation.php; then
+    if docker compose run --rm test php /tmp/verify-isolation.php; then
         log_success "Verification completed successfully"
         return 0
     else
@@ -274,7 +274,7 @@ generate_report() {
         log_info "Generating report file: $report_file"
         
         # Run verification and save to file
-        docker-compose run --rm test php /tmp/verify-isolation.php > "$report_file"
+        docker compose run --rm test php /tmp/verify-isolation.php > "$report_file"
         
         if [ $? -eq 0 ]; then
             log_success "Report generated: $report_file"


### PR DESCRIPTION
## Summary
- The scheduled `Comprehensive Testing` workflow has been failing in the **Setup test environment** step (run [25710577749](https://github.com/jloosli/power-of-families/actions/runs/25710577749) and prior). `bin/test-env-manager.sh` checked for the legacy V1 binary `docker-compose`, which is no longer present on GitHub's `ubuntu-24.04` runners — only the V2 `docker compose` plugin is shipped.
- Updated 15 bin scripts to use `docker compose` instead of `docker-compose`, and replaced the V1 availability check (`command -v docker-compose`) with the V2-compatible `docker compose version`.
- Filename references to `docker-compose.yml` are unchanged.

## Test plan
- [x] All modified scripts pass `bash -n` syntax check
- [x] `docker compose version` works locally and on the runner image
- [ ] `Comprehensive Testing` workflow passes on this branch (re-run after merge or via `workflow_dispatch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)