### PR TITLE
Fix CI: skip redundant host-side test DB setup

### DIFF
--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -152,16 +152,18 @@ execute_ci_tests() {
     # Run PHPUnit with coverage and reporting for CI/CD
     local phpunit_cmd="phpunit --configuration phpunit.xml"
     
-    # Add coverage flags if coverage is enabled
+    # Write coverage and reports to /var/www/html/{coverage,test-reports},
+    # which are bind-mounted to ./coverage and ./test-reports on the host.
+    # Using absolute paths here because CWD is the theme directory, so
+    # `coverage/clover.xml` would otherwise resolve under the theme tree.
     if [[ "$COMMON_OPTIONS" == *"--coverage-enabled"* ]]; then
-        phpunit_cmd="$phpunit_cmd --coverage-clover=coverage/clover.xml"
-        phpunit_cmd="$phpunit_cmd --coverage-html=coverage/html"
+        phpunit_cmd="$phpunit_cmd --coverage-clover=/var/www/html/coverage/clover.xml"
+        phpunit_cmd="$phpunit_cmd --coverage-html=/var/www/html/coverage/html"
         phpunit_cmd="$phpunit_cmd --coverage-text"
     fi
-    
-    # Add reporting flags if reports are enabled
+
     if [[ "$COMMON_OPTIONS" == *"--generate-reports"* ]]; then
-        phpunit_cmd="$phpunit_cmd --log-junit=test-reports/junit.xml"
+        phpunit_cmd="$phpunit_cmd --log-junit=/var/www/html/test-reports/junit.xml"
     fi
     
     # Execute the command

--- a/bin/test-env-manager.sh
+++ b/bin/test-env-manager.sh
@@ -280,15 +280,11 @@ setup_test_environment() {
         return 1
     fi
     
-    # Setup test database
-    log_info "Setting up test database..."
-    if bin/setup-test-db.sh; then
-        log_success "Test database setup complete"
-    else
-        log_error "Failed to setup test database"
-        return 1
-    fi
-    
+    # Note: the test database is created by bin/install-wp-tests.sh inside the
+    # test container during `docker compose run --rm test ci`, so a host-side
+    # setup step is not needed (and would fail on runners whose mysql client
+    # cannot reach the db service).
+
     # Initialize coverage thresholds
     log_info "Initializing coverage thresholds..."
     if bin/manage-coverage-thresholds.sh init; then


### PR DESCRIPTION
## Summary
Three infrastructure fixes that unblock the `Comprehensive Testing` workflow's Unit Tests job through to the coverage threshold check. The remaining failure is the threshold gate doing its job, not a bug — see "Known remaining failure" below.

### 1. Skip redundant host-side test DB setup
The "Setup test environment" step looped forever inside `bin/setup-test-db.sh` ([run 25715997793](https://github.com/jloosli/power-of-families/actions/runs/25715997793), canceled at ~5m) with:

  `mysqladmin: [ERROR] unknown variable 'ssl=0'`

The runner's MySQL 8 client removed `--ssl=0` (now `--ssl-mode=DISABLED`), so `mysqladmin ping` exits non-zero before attempting a connection — the `until` loop never succeeded. The host-side DB setup is redundant anyway: `bin/install-wp-tests.sh` already drops and recreates `wordpress_tests` inside the test container when `bin/run-tests-ci.sh` invokes `docker compose run --rm test ci`, and the `/tmp/test-db-config.php` file `setup-test-db.sh` wrote is not read by any other script. Removed the host-side call from `bin/test-env-manager.sh::setup_test_environment`.

### 2. Write coverage and reports to mounted host paths
The next run ([25716396742](https://github.com/jloosli/power-of-families/actions/runs/25716396742)) reached "Run unit tests" and tests passed — but the post-test step failed with `❌ Clover XML file not found: coverage/clover.xml`. `bin/run-tests.sh::execute_ci_tests` cd's into the theme directory and passed `--coverage-clover=coverage/clover.xml` as a relative path, so phpunit wrote to `wp-content/themes/power-of-families/coverage/` — not the `./coverage/` bind-mounted to `/var/www/html/coverage`. Switched to absolute `/var/www/html/coverage` and `/var/www/html/test-reports` paths so output lands at the host paths the coverage checks and artifact upload expect.

### Verification
[Run 25716594287](https://github.com/jloosli/power-of-families/actions/runs/25716594287) on this branch shows:
- ✅ Setup test environment
- ✅ Tests execute (`OK (24 tests, 65 assertions)`)
- ✅ Coverage report generated at `coverage/clover.xml`
- ❌ Coverage threshold check (see below)

## Known remaining failure (intentional, not addressed here)
The Unit Tests job still fails at the coverage threshold check. Actual coverage is far below configured minimums:

| Metric    | Actual          | Min in `coverage-thresholds.json` |
|-----------|-----------------|-----------------------------------|
| Classes   | 0% (0/11)       | 70% |
| Methods   | 15.3% (13/85)   | 60% |
| Lines     | 18.2% (154/845) | 50% |

Only `Avanti\ThemeSetup` has tests; the other classes (`POF\AdminAPI`, `POF\Settings`, `Avanti\WooCommerce`, etc.) are uncovered. The thresholds file is dated `2025-10-07`, predating the `wp-content` reorg that added the untested code. Per the maintainer's call, this PR leaves the gate as-is — the cron will keep failing until tests are added for the uncovered classes. The infrastructure fixes here are still worth merging so the failure mode is "real coverage gap" instead of "workflow can't even run".

🤖 Generated with [Claude Code](https://claude.com/claude-code)