### PR TITLE
Fix #39: accept null description in My_Programs

### DIFF
--- a/wp-content/themes/power-of-families/inc/PowerOfFamilies/POF/Programs/My_Programs.php
+++ b/wp-content/themes/power-of-families/inc/PowerOfFamilies/POF/Programs/My_Programs.php
@@ -76,10 +76,10 @@ class My_Programs
         return $output;
     }
 
-    private function getProgramMetaFromDescription( string $description ) : \stdClass
+    private function getProgramMetaFromDescription( ?string $description ) : \stdClass
     {
         $meta = new \stdClass();
-        $lines = explode("\n", $description);
+        $lines = explode("\n", $description ?? '');
         foreach ($lines as $line) {
             $parts = array_map('trim', explode(":", $line));
             if (count($parts) >= 2) {

--- a/wp-content/themes/power-of-families/phpunit.xml
+++ b/wp-content/themes/power-of-families/phpunit.xml
@@ -44,6 +44,7 @@
         <testsuite name="Theme Test Suite">
             <file>./tests/test-sample.php</file>
             <file>./tests/test-ThemeSetup.php</file>
+            <file>./tests/test-MyPrograms.php</file>
         </testsuite>
     </testsuites>
 

--- a/wp-content/themes/power-of-families/tests/test-MyPrograms.php
+++ b/wp-content/themes/power-of-families/tests/test-MyPrograms.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Tests for the My_Programs class.
+ *
+ * @package Power_Of_Families
+ */
+class test_MyPrograms extends WP_UnitTestCase {
+
+    private \PowerOfFamilies\POF\Programs\My_Programs $my_programs;
+    private ReflectionMethod $parse_description;
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->my_programs = new \PowerOfFamilies\POF\Programs\My_Programs();
+        $this->parse_description = new ReflectionMethod(
+            \PowerOfFamilies\POF\Programs\My_Programs::class,
+            'getProgramMetaFromDescription'
+        );
+        $this->parse_description->setAccessible( true );
+    }
+
+    // -------------------------------------------------------------------------
+    // getProgramMetaFromDescription — regression coverage for issue #39
+    //
+    // WordPress Groups stores `description` as a nullable TEXT column. The
+    // PHP 8.4 modernization briefly typed this parameter as a non-null string,
+    // which fatalled /my-account/ for any user whose group description was
+    // NULL. Lock that contract in.
+    // -------------------------------------------------------------------------
+
+    public function test_parses_null_description_without_fatal() {
+        $meta = $this->parse_description->invoke( $this->my_programs, null );
+
+        $this->assertInstanceOf( \stdClass::class, $meta );
+        $this->assertEmpty( get_object_vars( $meta ) );
+    }
+
+    public function test_parses_empty_description() {
+        $meta = $this->parse_description->invoke( $this->my_programs, '' );
+
+        $this->assertInstanceOf( \stdClass::class, $meta );
+        $this->assertEmpty( get_object_vars( $meta ) );
+    }
+
+    public function test_parses_image_and_home_metadata() {
+        $description = "image: https://example.com/i.png\nhome: https://example.com/program";
+
+        $meta = $this->parse_description->invoke( $this->my_programs, $description );
+
+        $this->assertSame( 'https://example.com/i.png', $meta->image );
+        $this->assertSame( 'https://example.com/program', $meta->home );
+    }
+
+    public function test_lines_without_colon_are_ignored() {
+        $description = "image: https://example.com/i.png\njust a free-form line\nhome: https://example.com";
+
+        $meta = $this->parse_description->invoke( $this->my_programs, $description );
+
+        $this->assertSame( 'https://example.com/i.png', $meta->image );
+        $this->assertSame( 'https://example.com', $meta->home );
+        $this->assertObjectNotHasProperty( 'just a free-form line', $meta );
+    }
+
+    public function test_keys_are_lowercased() {
+        $description = "IMAGE: https://example.com/i.png";
+
+        $meta = $this->parse_description->invoke( $this->my_programs, $description );
+
+        $this->assertSame( 'https://example.com/i.png', $meta->image );
+    }
+}


### PR DESCRIPTION
## Summary
- The PHP 8.4 modernization in `ef15a28` added a strict `string` type to `My_Programs::getProgramMetaFromDescription()`. WordPress Groups stores `description` as a nullable TEXT column, so any user whose group row had a NULL description hit a fatal `TypeError` on `/my-account/` and saw the WordPress "critical error" page (issue #39).
- Accept `?string` and coalesce null to `''` before `explode()`. Preserves intended behaviour: descriptions without parseable metadata yield an empty `stdClass`.

## Verification
Reproduced the exact production fatal against the pre-fix file using PHP 8.4:

```
Fatal error: Uncaught TypeError: ...getProgramMetaFromDescription():
  Argument #1 ($description) must be of type string, null given in My_Programs.php:79
```

After the fix, the same input (`null`) returns an empty `stdClass`. Also verified empty-string and a typical `image:\nhome:` description still parse correctly.

## Test plan
- [ ] CI passes (PHPUnit + lint)
- [ ] On staging/prod: log in as the affected customer (purchased Clutter Program 4/16/2026) and confirm `/my-account/` renders without the critical-error page
- [ ] Confirm `[pof_programs]` shortcode still renders program links and images for users whose description does contain metadata

Fixes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)