### PR TITLE
Chore: bump npm patch/minor devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,14 +15,14 @@
 				"postcss-nested": "^7.0.2"
 			},
 			"devDependencies": {
-				"@playwright/test": "^1.55.0",
-				"@types/node": "^24.3.1",
-				"@wordpress/prettier-config": "^4.27.0",
+				"@playwright/test": "^1.60.0",
+				"@types/node": "^24.12.4",
+				"@wordpress/prettier-config": "^4.45.0",
 				"@wordpress/scripts": "^32.1.0",
 				"normalize.css": "^8.0.1",
 				"postcss": "^8.5.14",
-				"prettier": "^3.2.5",
-				"wp-types": "^4.68.1"
+				"prettier": "^3.8.3",
+				"wp-types": "^4.69.0"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -5093,13 +5093,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-			"integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+			"integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.59.1"
+				"playwright": "1.60.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -5992,9 +5992,9 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "24.12.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
-			"integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+			"version": "24.12.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+			"integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7601,9 +7601,9 @@
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/@types/node": {
-			"version": "20.19.39",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-			"integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+			"version": "20.19.41",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+			"integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -8513,9 +8513,9 @@
 			}
 		},
 		"node_modules/autoprefixer": {
-			"version": "10.4.21",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
-			"integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+			"integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -8532,10 +8532,9 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.24.4",
-				"caniuse-lite": "^1.0.30001702",
-				"fraction.js": "^4.3.7",
-				"normalize-range": "^0.1.2",
+				"browserslist": "^4.28.2",
+				"caniuse-lite": "^1.0.30001787",
+				"fraction.js": "^5.3.4",
 				"picocolors": "^1.1.1",
 				"postcss-value-parser": "^4.2.0"
 			},
@@ -12746,15 +12745,15 @@
 			"license": "MIT"
 		},
 		"node_modules/fraction.js": {
-			"version": "4.3.7",
-			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
-			"integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+			"version": "5.3.4",
+			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+			"integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
 			"license": "MIT",
 			"engines": {
 				"node": "*"
 			},
 			"funding": {
-				"type": "patreon",
+				"type": "github",
 				"url": "https://github.com/sponsors/rawify"
 			}
 		},
@@ -16970,15 +16969,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/normalize-range": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-			"integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/normalize.css": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
@@ -17788,13 +17778,13 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-			"integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+			"integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.59.1"
+				"playwright-core": "1.60.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -17807,9 +17797,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-			"integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+			"integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -18715,9 +18705,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+			"integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -23425,9 +23415,9 @@
 			}
 		},
 		"node_modules/wp-types": {
-			"version": "4.68.1",
-			"resolved": "https://registry.npmjs.org/wp-types/-/wp-types-4.68.1.tgz",
-			"integrity": "sha512-PpyF5va7pxdBSV8cE3oao/Wfsrbx1gZKmBaijOd6/Q6RmuzCfUSPHtj8RzAtwDYD8dv7cga5lX63TvYTHdOIZA==",
+			"version": "4.69.0",
+			"resolved": "https://registry.npmjs.org/wp-types/-/wp-types-4.69.0.tgz",
+			"integrity": "sha512-2w0i2ygylpbYpqFskg1NlvH/1DM8thZuhxjihFRHdvjgFkmzJ2cHl2kq9cBnxYWHyLHzRiLI2TupKbq3yl2STQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -40,14 +40,14 @@
 		"test:docs": "bin/test-docs.sh"
 	},
 	"devDependencies": {
-		"@playwright/test": "^1.55.0",
-		"@types/node": "^24.3.1",
-		"@wordpress/prettier-config": "^4.27.0",
+		"@playwright/test": "^1.60.0",
+		"@types/node": "^24.12.4",
+		"@wordpress/prettier-config": "^4.45.0",
 		"@wordpress/scripts": "^32.1.0",
 		"normalize.css": "^8.0.1",
 		"postcss": "^8.5.14",
-		"prettier": "^3.2.5",
-		"wp-types": "^4.68.1"
+		"prettier": "^3.8.3",
+		"wp-types": "^4.69.0"
 	},
 	"overrides": {
 		"serialize-javascript": "^7.0.5",


### PR DESCRIPTION
## Summary
- Minor/patch bumps for tooling within existing semver ranges
- No security advisories triggered this — `npm audit` reports zero vulnerabilities both before and after
- @playwright/test, @types/node, @wordpress/prettier-config (floor), autoprefixer, prettier, wp-types

## Changes
| Package | From | To |
|---|---|---|
| @playwright/test | 1.59.1 | 1.60.0 |
| @types/node | 24.12.2 | 24.12.4 |
| @wordpress/prettier-config | 4.27.0 | 4.45.0 (floor) |
| autoprefixer | 10.4.21 | 10.5.0 |
| prettier | 3.6.2 | 3.8.3 |
| wp-types | 4.68.1 | 4.69.0 |

`@types/node` deliberately held at v24 to stay aligned with Node 24 in CI.

## Test plan
- [x] `npm ci` clean install
- [x] `npm run build` (theme + plugin) succeeds
- [x] `npm audit` reports 0 vulnerabilities
- [x] `prettier --check` warnings unchanged (pre-existing on 37 legacy files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)