### PR TITLE
Chore: bump PostCSS plugin majors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
 			"version": "3.0.0",
 			"license": "UNLICENSED",
 			"dependencies": {
-				"@csstools/postcss-global-data": "^3.0.0",
+				"@csstools/postcss-global-data": "^4.0.0",
 				"autoprefixer": "^10.4.21",
-				"postcss-custom-media": "^11.0.6",
+				"postcss-custom-media": "^12.0.1",
 				"postcss-nested": "^7.0.2"
 			},
 			"devDependencies": {
@@ -2091,29 +2091,6 @@
 				"@keyv/serialize": "^1.1.1"
 			}
 		},
-		"node_modules/@csstools/cascade-layer-name-parser": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@csstools/cascade-layer-name-parser/-/cascade-layer-name-parser-2.0.5.tgz",
-			"integrity": "sha512-p1ko5eHgV+MgXFVa4STPKpvPxr6ReS8oS2jzTukjR74i5zJNyWO1ZM1m8YKBXnzDKWfBN1ztLYlHxbVemDD88A==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^3.0.5",
-				"@csstools/css-tokenizer": "^3.0.4"
-			}
-		},
 		"node_modules/@csstools/color-helpers": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
@@ -2190,6 +2167,7 @@
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
 			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2212,6 +2190,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
 			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2252,9 +2231,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-global-data": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-global-data/-/postcss-global-data-3.0.0.tgz",
-			"integrity": "sha512-3dR5+RDhPW1uqPWZUyTBSVn03gGbxzoSyCEpXugy9UMtXeyKjrB84dX3V8eggzooCsX8wcraKehzdouNO+MlsA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-global-data/-/postcss-global-data-4.0.0.tgz",
+			"integrity": "sha512-mPKrL3Tzt8k1V+hTkU8XTH6JKRekB97oKHv/MekC9nfmRa+gMf1swlHRt8YK722sYN4xOipl17FZst99jsScLA==",
 			"funding": [
 				{
 					"type": "github",
@@ -2267,7 +2246,7 @@
 			],
 			"license": "MIT-0",
 			"engines": {
-				"node": ">=18"
+				"node": ">=20.19.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
@@ -17942,9 +17921,9 @@
 			}
 		},
 		"node_modules/postcss-custom-media": {
-			"version": "11.0.6",
-			"resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-11.0.6.tgz",
-			"integrity": "sha512-C4lD4b7mUIw+RZhtY7qUbf4eADmb7Ey8BFA2px9jUbwg7pjTZDl4KY4bvlUV+/vXQvzQRfiGEVJyAbtOsCMInw==",
+			"version": "12.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-12.0.1.tgz",
+			"integrity": "sha512-66syE14+VeqkUf0rRX0bvbTCbNRJF132jD+ceo8th1dap2YJEAqpdh5uG98CE3IbgHT7m9XM0GIlOazNWqQdeA==",
 			"funding": [
 				{
 					"type": "github",
@@ -17957,22 +17936,22 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/cascade-layer-name-parser": "^2.0.5",
-				"@csstools/css-parser-algorithms": "^3.0.5",
-				"@csstools/css-tokenizer": "^3.0.4",
-				"@csstools/media-query-list-parser": "^4.0.3"
+				"@csstools/cascade-layer-name-parser": "^3.0.0",
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0",
+				"@csstools/media-query-list-parser": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20.19.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
-		"node_modules/postcss-custom-media/node_modules/@csstools/media-query-list-parser": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz",
-			"integrity": "sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==",
+		"node_modules/postcss-custom-media/node_modules/@csstools/cascade-layer-name-parser": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/cascade-layer-name-parser/-/cascade-layer-name-parser-3.0.0.tgz",
+			"integrity": "sha512-/3iksyevwRfSJx5yH0RkcrcYXwuhMQx3Juqf40t97PeEy2/Mz2TItZ/z/216qpe4GgOyFBP8MKIwVvytzHmfIQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -17985,11 +17964,75 @@
 			],
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=20.19.0"
 			},
 			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^3.0.5",
-				"@csstools/css-tokenizer": "^3.0.4"
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/postcss-custom-media/node_modules/@csstools/css-parser-algorithms": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/postcss-custom-media/node_modules/@csstools/css-tokenizer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+			"integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			}
+		},
+		"node_modules/postcss-custom-media/node_modules/@csstools/media-query-list-parser": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-5.0.0.tgz",
+			"integrity": "sha512-T9lXmZOfnam3eMERPsszjY5NK0jX8RmThmmm99FZ8b7z8yMaFZWKwLWGZuTwdO3ddRY5fy13GmmEYZXB4I98Eg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
 			}
 		},
 		"node_modules/postcss-discard-comments": {

--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
 		"webpack-dev-server": "^5.2.1"
 	},
 	"dependencies": {
-		"@csstools/postcss-global-data": "^3.0.0",
+		"@csstools/postcss-global-data": "^4.0.0",
 		"autoprefixer": "^10.4.21",
-		"postcss-custom-media": "^11.0.6",
+		"postcss-custom-media": "^12.0.1",
 		"postcss-nested": "^7.0.2"
 	}
 }


### PR DESCRIPTION
## Summary
- `@csstools/postcss-global-data` 3.0.0 → 4.0.0 (major)
- `postcss-custom-media` 11.0.6 → 12.0.1 (major)
- Independent of #52 — branched from `main`, no overlap

## Risk
Both are PostCSS plugin majors. Compiled CSS was diffed before and after the bump:

```
diff main.ts.css.before main.ts.css.after     → 0 lines
diff main.ts-rtl.css.before main.ts-rtl.css.after → 0 lines
```

Byte-identical output, so no visual regression is expected for this codebase. The breaking changes in these majors apparently affect features we don't use.

## Test plan
- [x] `npm install` clean
- [x] `npm run build:theme` succeeds
- [x] Compiled CSS byte-identical to pre-bump output
- [x] `npm audit` reports 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)