### PR TITLE
Add local update smoke testing (bin/smoke + Playwright)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ test-reports/
 # xDebug logs and profiles
 xdebug-logs/
 xdebug-profiles/
+
+# Smoke testing artifacts
+tests/smoke/test-results/
+tests/smoke/playwright-report/

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ test-reports/
 xdebug-logs/
 xdebug-profiles/
 
-# Smoke testing artifacts
+# Smoke testing artifacts (both cwd-relative and config-relative output dirs)
+test-results/
 tests/smoke/test-results/
+playwright-report/
 tests/smoke/playwright-report/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ of which DB pattern you pick.
 | Watch theme | `npm run start:theme` |
 | Watch plugin | `npm run start:plugin` |
 | Run tests | `npm run test` |
+| Smoke-test the site after a plugin / theme / core update | `npm run smoke` (one-time setup: `npm run smoke:install`) |
 
 ## Key Facts
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,15 @@ to also fail on PHP warnings / notices / deprecated calls.
 
 Test fixtures (a `smoketest@example.com` user, a `Smoke Test Product`,
 and a gated members page) are seeded idempotently by `bin/smoke-fixtures`
-on every run; no manual setup needed beyond `npm run smoke:install`.
+on every run; no manual setup needed beyond `npm run smoke:install`. The
+fixture script also sets `woocommerce_force_ssl_checkout=no` so the local
+HTTP-only stack can render `/checkout/` — a side effect that persists on
+the DB it runs against.
+
+Design rationale and the implementation plan live in
+[`docs/superpowers/specs/2026-05-14-update-smoke-testing-design.md`](docs/superpowers/specs/2026-05-14-update-smoke-testing-design.md)
+and
+[`docs/superpowers/plans/2026-05-14-update-smoke-testing.md`](docs/superpowers/plans/2026-05-14-update-smoke-testing.md).
 
 ## Miscellaneous
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ docker compose run --rm wpcli plugin update <slug>   # or theme update / core up
 npm run smoke
 
 # 3. If green, mirror to prod
-ssh pof 'wp plugin update <slug>'   # or however remote WP-CLI is invoked
+ssh pof 'cd ~/html && wp plugin update <slug>'   # WP install lives in ~/html on prod
 
 # 4. If red, revert locally
 docker compose run --rm wpcli plugin install <slug> --version=<previous> --force

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 1. Update WordPress and database to the latest version.
 1. Download the database backup: `npm run setup:db-download`
 1. Import the database: `npm run setup:db-import`
-   - You can also use [phpMyAdmin](http://localhost:8180) to upload the database. See [docker-compose.yml](docker-compose.yml) for credentials.
+    - You can also use [phpMyAdmin](http://localhost:8180) to upload the database. See [docker-compose.yml](docker-compose.yml) for credentials.
 1. Sync the genesis theme: `npm run setup:sync-themes`
 1. Sync the plugins: `npm run setup:sync-plugins`
 1. Install composer dependencies: `npm run setup:composer-install`
@@ -63,11 +63,11 @@ The DB volume is large (~1.6 GB) and re-running first-time setup in every
 worktree is wasteful. Three patterns, depending on how isolated you want
 to be:
 
-| | DB | `wordpress/` install | Use when |
-|---|---|---|---|
-| **A. Independent DB, shared install** | own copy (stdin import) | symlink to main | branch work that may mutate DB — keep main's data safe |
-| **B. Live-shared DB** | main's running container | symlink to main | quick lookups / read-mostly work; ok with shared writes |
-| **C. Full symlink** | symlinked db-data | symlink to main | maximum sharing; only one stack's `db` may run at a time |
+|                                       | DB                       | `wordpress/` install | Use when                                                 |
+| ------------------------------------- | ------------------------ | -------------------- | -------------------------------------------------------- |
+| **A. Independent DB, shared install** | own copy (stdin import)  | symlink to main      | branch work that may mutate DB — keep main's data safe   |
+| **B. Live-shared DB**                 | main's running container | symlink to main      | quick lookups / read-mostly work; ok with shared writes  |
+| **C. Full symlink**                   | symlinked db-data        | symlink to main      | maximum sharing; only one stack's `db` may run at a time |
 
 In all three, the worktree's bind mounts of `wp-content/themes/power-of-families`
 and `wp-content/plugins/pof-bloom-plugin` overlay the shared WP install, so
@@ -145,14 +145,14 @@ them from scratch.
 
 ### Reference: Docker compose env overrides
 
-| Var                | Default | Used in                    |
-| ------------------ | ------- | -------------------------- |
-| `WP_PORT`          | `8080`  | wordpress host port        |
-| `PHPMYADMIN_PORT`  | `8180`  | phpmyadmin host port       |
-| `XDEBUG_PORT`      | `9003`  | wordpress + test xDebug    |
-| `PHP_VERSION`      | `8.4`   | wordpress + test image     |
-| `MARIA_DB_VERSION` | `10.11.14` | db image                |
-| `WORDPRESS_DEBUG`  | `false` | `WORDPRESS_SCRIPT_DEBUG`   |
+| Var                | Default    | Used in                  |
+| ------------------ | ---------- | ------------------------ |
+| `WP_PORT`          | `8080`     | wordpress host port      |
+| `PHPMYADMIN_PORT`  | `8180`     | phpmyadmin host port     |
+| `XDEBUG_PORT`      | `9003`     | wordpress + test xDebug  |
+| `PHP_VERSION`      | `8.4`      | wordpress + test image   |
+| `MARIA_DB_VERSION` | `10.11.14` | db image                 |
+| `WORDPRESS_DEBUG`  | `false`    | `WORDPRESS_SCRIPT_DEBUG` |
 
 ### Bumping the PHP version
 
@@ -200,6 +200,54 @@ npm run build:plugin
 ```shell
 npm run build
 ```
+
+### Smoke Testing After Updates
+
+`bin/smoke` exercises the public site, members login + gated content, and
+the WooCommerce add-to-cart → checkout-render flow, then tails the
+WordPress container's PHP error log. Run it after each local plugin /
+theme / core update; only mirror an update to production once it's green.
+
+**One-time setup (per worktree, after first checkout):**
+
+```shell
+npm run smoke:install   # downloads Chromium
+```
+
+**Discovering pending updates:**
+
+```shell
+docker compose run --rm wpcli plugin list --update=available
+docker compose run --rm wpcli theme list --update=available
+docker compose run --rm wpcli core check-update
+```
+
+These commands print every plugin/theme/core update available — no slug
+list to maintain.
+
+**The update loop:**
+
+```shell
+# 1. Update one thing locally
+docker compose run --rm wpcli plugin update <slug>   # or theme update / core update
+
+# 2. Smoke test
+npm run smoke
+
+# 3. If green, mirror to prod
+ssh pof 'wp plugin update <slug>'   # or however remote WP-CLI is invoked
+
+# 4. If red, revert locally
+docker compose run --rm wpcli plugin install <slug> --version=<previous> --force
+```
+
+The smoke suite is plugin-agnostic — it never sees which plugin was just
+updated. Run it after any single update. Use `npm run smoke -- --strict`
+to also fail on PHP warnings / notices / deprecated calls.
+
+Test fixtures (a `smoketest@example.com` user, a `Smoke Test Product`,
+and a gated members page) are seeded idempotently by `bin/smoke-fixtures`
+on every run; no manual setup needed beyond `npm run smoke:install`.
 
 ## Miscellaneous
 

--- a/bin/smoke
+++ b/bin/smoke
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# One-shot smoke test for after a plugin / theme / core update.
+#
+# Pipeline:
+#   1. Confirm the wordpress container is up.
+#   2. Record the docker-logs cutoff timestamp.
+#   3. Seed fixtures (idempotent) and export their identifiers.
+#   4. Run Playwright.
+#   5. Slice the wordpress container logs since the cutoff and check for
+#      PHP fatals / parse errors / uncaught exceptions. With --strict, also
+#      fail on warnings / notices / deprecations.
+#
+# Exits 0 only if Playwright passed AND the log slice is clean.
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+cd "$ROOT_DIR"
+
+STRICT=0
+for arg in "$@"; do
+    case "$arg" in
+        --strict) STRICT=1 ;;
+        -h|--help)
+            cat <<EOF
+Usage: bin/smoke [--strict]
+
+  --strict   also fail on PHP Warning / PHP Notice / Deprecated
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# Source .env if present so WP_PORT (and friends) are available to
+# bin/smoke-fixtures and Playwright. Compose reads .env automatically;
+# the host-side tools (this script, Playwright) do not.
+if [[ -f .env ]]; then
+    set -a
+    . ./.env
+    set +a
+fi
+
+# 1. Container check.
+if ! docker compose ps --status=running --services 2>/dev/null | grep -qx wordpress; then
+    cat >&2 <<EOF
+wordpress container is not running. Bring it up first:
+
+    docker compose up -d wordpress
+
+EOF
+    exit 1
+fi
+
+# 2. Cutoff timestamp (RFC3339, UTC).
+SMOKE_LOG_SINCE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# 3. Seed fixtures and export their KEY=value output as env vars.
+echo "==> Seeding smoke fixtures…" >&2
+FIXTURES_OUT=$(bin/smoke-fixtures)
+while IFS= read -r line; do
+    [[ -z "$line" || "$line" != *=* ]] && continue
+    export "$line"
+done <<< "$FIXTURES_OUT"
+
+# 4. Run Playwright.
+echo "==> Running Playwright smoke suite…" >&2
+PLAYWRIGHT_EXIT=0
+npx playwright test --config tests/smoke/playwright.config.ts || PLAYWRIGHT_EXIT=$?
+
+# 5. Log slice.
+echo "==> Checking PHP error log since ${SMOKE_LOG_SINCE}…" >&2
+LOG_SLICE=$(docker compose logs wordpress --since="$SMOKE_LOG_SINCE" --no-color 2>&1 || true)
+
+if [[ "$STRICT" -eq 1 ]]; then
+    PATTERN='PHP Fatal|PHP Parse|Uncaught|PHP Warning|PHP Notice|Deprecated'
+else
+    PATTERN='PHP Fatal|PHP Parse|Uncaught'
+fi
+
+LOG_HITS=$(echo "$LOG_SLICE" | grep -E "$PATTERN" || true)
+LOG_EXIT=0
+if [[ -n "$LOG_HITS" ]]; then
+    LOG_EXIT=1
+    echo "==> PHP error log slice contained errors:" >&2
+    echo "$LOG_HITS" >&2
+fi
+
+if [[ "$PLAYWRIGHT_EXIT" -ne 0 || "$LOG_EXIT" -ne 0 ]]; then
+    echo "==> SMOKE FAILED (playwright=$PLAYWRIGHT_EXIT, log=$LOG_EXIT)" >&2
+    exit 1
+fi
+
+echo "==> SMOKE PASSED" >&2

--- a/bin/smoke-fixtures
+++ b/bin/smoke-fixtures
@@ -10,6 +10,9 @@ SMOKE_USER_EMAIL="smoketest@example.com"
 SMOKE_USER_LOGIN="smoketest"
 SMOKE_PASSWORD="${SMOKE_PASSWORD:-smoke-test-pw-change-me}"
 
+SMOKE_PRODUCT_SLUG="smoke-test-product"
+SMOKE_PRODUCT_TITLE="Smoke Test Product"
+
 wpcli() {
     docker compose run --rm -T wpcli "$@"
 }
@@ -24,8 +27,39 @@ ensure_user() {
         --display_name="Smoke Test" >/dev/null
 }
 
+ensure_product() {
+    local existing
+    existing=$(wpcli post list \
+        --post_type=product \
+        --name="$SMOKE_PRODUCT_SLUG" \
+        --field=ID \
+        --format=ids 2>/dev/null | tr -d '[:space:]')
+    if [[ -n "$existing" ]]; then
+        return 0
+    fi
+    local id
+    id=$(wpcli post create \
+        --post_type=product \
+        --post_status=publish \
+        --post_title="$SMOKE_PRODUCT_TITLE" \
+        --post_name="$SMOKE_PRODUCT_SLUG" \
+        --porcelain)
+    # Resolve an admin user ID (WooCommerce CLI requires a valid WP user).
+    local admin_id
+    admin_id=$(wpcli user list --role=administrator --field=ID --format=ids 2>/dev/null \
+        | tr ' ' '\n' | head -1 | tr -d '[:space:]')
+    # Make it a simple, purchasable product priced $1 with stock management off.
+    wpcli wc product update "$id" \
+        --type=simple \
+        --regular_price=1 \
+        --manage_stock=false \
+        --user="$admin_id" >/dev/null
+}
+
 ensure_user
+ensure_product
 
 echo "SMOKE_USER_EMAIL=$SMOKE_USER_EMAIL"
 echo "SMOKE_USER_LOGIN=$SMOKE_USER_LOGIN"
 echo "SMOKE_PASSWORD=$SMOKE_PASSWORD"
+echo "SMOKE_PRODUCT_SLUG=$SMOKE_PRODUCT_SLUG"

--- a/bin/smoke-fixtures
+++ b/bin/smoke-fixtures
@@ -167,8 +167,15 @@ GATED_ID=$(wpcli eval \
 local_url() {
     # $1 = raw URL from wp post url (e.g. https://poweroffamilies.com/product/foo/)
     # Returns $SITE_URL + path (e.g. http://localhost:8081/product/foo/)
+    # Exits non-zero if the input isn't a recognizable absolute URL — that
+    # way a missing/garbled raw URL fails loudly here rather than producing
+    # a malformed http://localhost:8081// that 404s silently in Playwright.
     local raw path
     raw="$1"
+    if [[ ! "$raw" =~ ^https?://[^/]+/ ]]; then
+        echo "local_url: expected an absolute http(s) URL with a path, got: ${raw:-<empty>}" >&2
+        exit 1
+    fi
     path="${raw#http*://*/}"      # strip scheme + host
     path="/${path%/}/"            # ensure leading slash and trailing slash
     printf '%s%s' "$SITE_URL" "$path"

--- a/bin/smoke-fixtures
+++ b/bin/smoke-fixtures
@@ -125,7 +125,7 @@ ensure_user_in_group() {
         echo "ensure_user_in_group: smoketest user not found" >&2
         exit 1
     fi
-    wpcli eval "global \$wpdb; \$wpdb->query(\"INSERT IGNORE INTO wp_groups_user_group (user_id, group_id) VALUES (${user_id}, ${SMOKE_GROUP_ID})\");" >/dev/null
+    wpcli eval "global \$wpdb; \$wpdb->query(\$wpdb->prepare(\"INSERT IGNORE INTO wp_groups_user_group (user_id, group_id) VALUES (%d, %d)\", ${user_id}, ${SMOKE_GROUP_ID}));" >/dev/null
 }
 
 ensure_user

--- a/bin/smoke-fixtures
+++ b/bin/smoke-fixtures
@@ -128,10 +128,19 @@ ensure_user_in_group() {
     wpcli eval "global \$wpdb; \$wpdb->query(\$wpdb->prepare(\"INSERT IGNORE INTO wp_groups_user_group (user_id, group_id) VALUES (%d, %d)\", ${user_id}, ${SMOKE_GROUP_ID}));" >/dev/null
 }
 
+ensure_woo_settings() {
+    # The local docker stack only serves HTTP (no HTTPS port exposed), so
+    # woocommerce_force_ssl_checkout must be off; otherwise /checkout/ redirects
+    # to https://localhost:PORT/checkout/ which no browser can reach in CI.
+    # This is idempotent — safe to run even if already set correctly.
+    wpcli option update woocommerce_force_ssl_checkout no >/dev/null
+}
+
 ensure_user
 ensure_product
 ensure_gated_page
 ensure_user_in_group
+ensure_woo_settings
 
 # ---------------------------------------------------------------------
 # Resolve URLs

--- a/bin/smoke-fixtures
+++ b/bin/smoke-fixtures
@@ -133,9 +133,71 @@ ensure_product
 ensure_gated_page
 ensure_user_in_group
 
-echo "SMOKE_USER_EMAIL=$SMOKE_USER_EMAIL"
-echo "SMOKE_USER_LOGIN=$SMOKE_USER_LOGIN"
-echo "SMOKE_PASSWORD=$SMOKE_PASSWORD"
-echo "SMOKE_PRODUCT_SLUG=$SMOKE_PRODUCT_SLUG"
-echo "SMOKE_GATED_SLUG=$SMOKE_GATED_SLUG"
-echo "SMOKE_GATED_MARKER=$SMOKE_GATED_MARKER"
+# ---------------------------------------------------------------------
+# Resolve URLs
+# ---------------------------------------------------------------------
+WP_PORT_LOCAL="${WP_PORT:-8081}"
+SITE_URL="http://localhost:${WP_PORT_LOCAL}"
+
+LATEST_POST_ID=$(wpcli post list \
+    --post_type=post \
+    --post_status=publish \
+    --posts_per_page=1 \
+    --field=ID \
+    --format=ids 2>/dev/null | tr -d '[:space:]')
+
+if [[ -z "$LATEST_POST_ID" ]]; then
+    echo "ERROR: no published posts found — public-pages spec needs one" >&2
+    exit 1
+fi
+
+PRODUCT_ID=$(wpcli post list \
+    --post_type=product \
+    --name="$SMOKE_PRODUCT_SLUG" \
+    --field=ID \
+    --format=ids 2>/dev/null | tr -d '[:space:]')
+
+# Look up gated page ID via $wpdb (groups plugin filters it from wp post list).
+GATED_ID=$(wpcli eval \
+    "global \$wpdb; echo \$wpdb->get_var(\$wpdb->prepare(\"SELECT ID FROM wp_posts WHERE post_name = %s AND post_type = 'page' AND post_status = 'publish'\", '${SMOKE_GATED_SLUG}'));" \
+    2>/dev/null | tr -d '[:space:]')
+
+# wp post url returns URLs with the production domain; extract the path and
+# prepend SITE_URL so every URL points to the local dev environment.
+local_url() {
+    # $1 = raw URL from wp post url (e.g. https://poweroffamilies.com/product/foo/)
+    # Returns $SITE_URL + path (e.g. http://localhost:8081/product/foo/)
+    local raw path
+    raw="$1"
+    path="${raw#http*://*/}"      # strip scheme + host
+    path="/${path%/}/"            # ensure leading slash and trailing slash
+    printf '%s%s' "$SITE_URL" "$path"
+}
+
+raw_latest=$(wpcli post url "$LATEST_POST_ID" 2>/dev/null | tr -d '[:space:]')
+SMOKE_LATEST_POST_URL=$(local_url "$raw_latest")
+
+raw_product=$(wpcli post url "$PRODUCT_ID" 2>/dev/null | tr -d '[:space:]')
+SMOKE_PRODUCT_URL=$(local_url "$raw_product")
+
+# wp post url may return empty for a gated page because groups plugin filters
+# it from WP queries; fall back to constructing the URL from the slug.
+raw_gated=$(wpcli post url "$GATED_ID" 2>/dev/null | tr -d '[:space:]')
+if [[ -n "$raw_gated" ]]; then
+    SMOKE_GATED_URL=$(local_url "$raw_gated")
+else
+    SMOKE_GATED_URL="${SITE_URL}/${SMOKE_GATED_SLUG}/"
+fi
+
+cat <<EOF
+SMOKE_USER_EMAIL=$SMOKE_USER_EMAIL
+SMOKE_USER_LOGIN=$SMOKE_USER_LOGIN
+SMOKE_PASSWORD=$SMOKE_PASSWORD
+SMOKE_PRODUCT_SLUG=$SMOKE_PRODUCT_SLUG
+SMOKE_PRODUCT_URL=$SMOKE_PRODUCT_URL
+SMOKE_GATED_SLUG=$SMOKE_GATED_SLUG
+SMOKE_GATED_URL=$SMOKE_GATED_URL
+SMOKE_GATED_MARKER=$SMOKE_GATED_MARKER
+SMOKE_LATEST_POST_URL=$SMOKE_LATEST_POST_URL
+SITE_URL=$SITE_URL
+EOF

--- a/bin/smoke-fixtures
+++ b/bin/smoke-fixtures
@@ -48,6 +48,10 @@ ensure_product() {
     local admin_id
     admin_id=$(wpcli user list --role=administrator --field=ID --format=ids 2>/dev/null \
         | tr ' ' '\n' | head -1 | tr -d '[:space:]')
+    if [[ -z "$admin_id" ]]; then
+        echo "ensure_product: no administrator user found to authenticate the WooCommerce update" >&2
+        exit 1
+    fi
     # Make it a simple, purchasable product priced $1 with stock management off.
     wpcli wc product update "$id" \
         --type=simple \

--- a/bin/smoke-fixtures
+++ b/bin/smoke-fixtures
@@ -13,6 +13,34 @@ SMOKE_PASSWORD="${SMOKE_PASSWORD:-smoke-test-pw-change-me}"
 SMOKE_PRODUCT_SLUG="smoke-test-product"
 SMOKE_PRODUCT_TITLE="Smoke Test Product"
 
+# ---------------------------------------------------------------------
+# Members-plugin gating decision (resolved 2026-05-14, Task 4 of plan).
+#
+# Active plugin:      groups (v3.7.0) + groups-woocommerce (v3.0.0)
+#                     members (v3.2.18) is active but its content_permissions
+#                     feature is OFF (option members_settings.content_permissions=0),
+#                     so it is NOT enforcing any page-level access.
+#
+# Gating mechanism:   `groups` plugin, postmeta key `groups-read`, value = group_id.
+#                     When a logged-out (or non-member) visitor hits a gated page,
+#                     WordPress returns HTTP 404 — no redirect, just a hard 404.
+#                     71 published posts/pages are gated this way.
+#
+# Example gated page: "Joy School Materials" (ID 57829, slug joy-school-materials-2)
+#                     groups-read = 83 ("Joy School Lifetime") and 84 ("Joy School
+#                     Parent Materials").
+#                     Simplest group for test purposes: group_id=1 ("Registered"),
+#                     which is the base membership tier every registered user joins.
+#
+# Test strategy for
+#   Task 5:           Create a page (slug smoke-test-gated) with postmeta
+#                     groups-read = 1 (group "Registered"). The smoketest user
+#                     (role=subscriber) must also be added to group_id=1 via the
+#                     groups plugin user-group table (wp_groups_user_group) so the
+#                     logged-in smoke test sees the page content, while the
+#                     logged-out check gets a 404. No shortcodes needed; the gating
+#                     is purely meta-driven by the groups plugin at request time.
+# ---------------------------------------------------------------------
 wpcli() {
     docker compose run --rm -T wpcli "$@"
 }

--- a/bin/smoke-fixtures
+++ b/bin/smoke-fixtures
@@ -136,7 +136,7 @@ ensure_user_in_group
 # ---------------------------------------------------------------------
 # Resolve URLs
 # ---------------------------------------------------------------------
-WP_PORT_LOCAL="${WP_PORT:-8081}"
+WP_PORT_LOCAL="${WP_PORT:-8080}"
 SITE_URL="http://localhost:${WP_PORT_LOCAL}"
 
 LATEST_POST_ID=$(wpcli post list \

--- a/bin/smoke-fixtures
+++ b/bin/smoke-fixtures
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Idempotently seed test fixtures for bin/smoke. Each fixture checks before
+# creating, so this script is safe to re-run.
+#
+# Emits KEY=value lines on stdout so bin/smoke can `eval` / export them as
+# env vars for the Playwright suite.
+set -euo pipefail
+
+SMOKE_USER_EMAIL="smoketest@example.com"
+SMOKE_USER_LOGIN="smoketest"
+SMOKE_PASSWORD="${SMOKE_PASSWORD:-smoke-test-pw-change-me}"
+
+wpcli() {
+    docker compose run --rm -T wpcli "$@"
+}
+
+ensure_user() {
+    if wpcli user get "$SMOKE_USER_EMAIL" --field=ID >/dev/null 2>&1; then
+        return 0
+    fi
+    wpcli user create "$SMOKE_USER_LOGIN" "$SMOKE_USER_EMAIL" \
+        --role=subscriber \
+        --user_pass="$SMOKE_PASSWORD" \
+        --display_name="Smoke Test" >/dev/null
+}
+
+ensure_user
+
+echo "SMOKE_USER_EMAIL=$SMOKE_USER_EMAIL"
+echo "SMOKE_USER_LOGIN=$SMOKE_USER_LOGIN"
+echo "SMOKE_PASSWORD=$SMOKE_PASSWORD"

--- a/bin/smoke-fixtures
+++ b/bin/smoke-fixtures
@@ -13,6 +13,11 @@ SMOKE_PASSWORD="${SMOKE_PASSWORD:-smoke-test-pw-change-me}"
 SMOKE_PRODUCT_SLUG="smoke-test-product"
 SMOKE_PRODUCT_TITLE="Smoke Test Product"
 
+SMOKE_GATED_SLUG="smoke-test-members-page"
+SMOKE_GATED_TITLE="Smoke Test Members Page"
+SMOKE_GATED_MARKER="MEMBERS_ONLY_MARKER"
+SMOKE_GROUP_ID="1"   # "Registered" group — base tier; see comment at top of file.
+
 # ---------------------------------------------------------------------
 # Members-plugin gating decision (resolved 2026-05-14, Task 4 of plan).
 #
@@ -88,10 +93,49 @@ ensure_product() {
         --user="$admin_id" >/dev/null
 }
 
+ensure_gated_page() {
+    # `wpcli post list --name=...` does not reliably filter by exact slug;
+    # query via $wpdb instead to get an exact match on post_name.
+    local existing
+    existing=$(wpcli eval \
+        "global \$wpdb; echo \$wpdb->get_var(\$wpdb->prepare(\"SELECT ID FROM wp_posts WHERE post_name = %s AND post_type = 'page' AND post_status = 'publish'\", '${SMOKE_GATED_SLUG}'));" \
+        2>/dev/null | tr -d '[:space:]')
+    if [[ -z "$existing" ]]; then
+        existing=$(wpcli post create \
+            --post_type=page \
+            --post_status=publish \
+            --post_title="$SMOKE_GATED_TITLE" \
+            --post_name="$SMOKE_GATED_SLUG" \
+            --post_content="Public preamble. $SMOKE_GATED_MARKER" \
+            --porcelain)
+    fi
+    # Ensure the groups-read meta is set to our target group. Idempotent
+    # via wp post meta update (creates or replaces).
+    wpcli post meta update "$existing" groups-read "$SMOKE_GROUP_ID" >/dev/null
+}
+
+ensure_user_in_group() {
+    # Add smoketest user to group_id=$SMOKE_GROUP_ID by inserting into
+    # the groups plugin's wp_groups_user_group mapping. Idempotent via
+    # INSERT IGNORE. Uses wpcli eval + $wpdb to avoid SSL issues with
+    # `wpcli db query` against MariaDB.
+    local user_id
+    user_id=$(wpcli user get "$SMOKE_USER_EMAIL" --field=ID 2>/dev/null | tr -d '[:space:]')
+    if [[ -z "$user_id" ]]; then
+        echo "ensure_user_in_group: smoketest user not found" >&2
+        exit 1
+    fi
+    wpcli eval "global \$wpdb; \$wpdb->query(\"INSERT IGNORE INTO wp_groups_user_group (user_id, group_id) VALUES (${user_id}, ${SMOKE_GROUP_ID})\");" >/dev/null
+}
+
 ensure_user
 ensure_product
+ensure_gated_page
+ensure_user_in_group
 
 echo "SMOKE_USER_EMAIL=$SMOKE_USER_EMAIL"
 echo "SMOKE_USER_LOGIN=$SMOKE_USER_LOGIN"
 echo "SMOKE_PASSWORD=$SMOKE_PASSWORD"
 echo "SMOKE_PRODUCT_SLUG=$SMOKE_PRODUCT_SLUG"
+echo "SMOKE_GATED_SLUG=$SMOKE_GATED_SLUG"
+echo "SMOKE_GATED_MARKER=$SMOKE_GATED_MARKER"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,8 +59,9 @@ services:
               source: ./wp-content/themes/power-of-families
               target: /var/www/html/wp-content/themes/power-of-families
             # Bump PHP memory_limit (image default 128M OOMs at boot with the
-            # full plugin set). The previous PHP_MEMORY_LIMIT env var below is
-            # not honored by the wordpress:cli image — this ini file is.
+            # full plugin set). PHP_MEMORY_LIMIT / WP_MEMORY_LIMIT env vars are
+            # not honored by the wordpress:cli image, so a php.ini override is
+            # the only mechanism that works.
             - ./docker/wp-cli.ini:/usr/local/etc/php/conf.d/zz-wp-cli.ini:ro
         working_dir: /var/www/html
         environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,15 +58,16 @@ services:
             - type: bind
               source: ./wp-content/themes/power-of-families
               target: /var/www/html/wp-content/themes/power-of-families
+            # Bump PHP memory_limit (image default 128M OOMs at boot with the
+            # full plugin set). The previous PHP_MEMORY_LIMIT env var below is
+            # not honored by the wordpress:cli image — this ini file is.
+            - ./docker/wp-cli.ini:/usr/local/etc/php/conf.d/zz-wp-cli.ini:ro
         working_dir: /var/www/html
         environment:
             WORDPRESS_DB_HOST: db
             WORDPRESS_DB_USER: pofuser
             WORDPRESS_DB_PASSWORD: pofpass
             WORDPRESS_DB_NAME: poweroffamilies
-            PHP_MEMORY_LIMIT: 20G
-            WP_MEMORY_LIMIT: 20G
-            WP_CLI_PHP_MEMORY_LIMIT: 4G
 
     db:
         image: mariadb:${MARIA_DB_VERSION:-10.11.14}

--- a/docker/wp-cli.ini
+++ b/docker/wp-cli.ini
@@ -1,0 +1,8 @@
+; PHP overrides for the `wpcli` docker-compose service.
+;
+; The wordpress:cli image's PHP defaults to memory_limit=128M, which OOMs at
+; boot under this site's full plugin set (Jetpack + WooCommerce + members).
+; Note: the docker-compose.yml `PHP_MEMORY_LIMIT` env var is NOT honored by
+; this image — it only affects WordPress's PHP runtime, not WP-CLI's. This
+; file is the real fix.
+memory_limit = 512M

--- a/docs/superpowers/plans/2026-05-14-update-smoke-testing.md
+++ b/docs/superpowers/plans/2026-05-14-update-smoke-testing.md
@@ -1,0 +1,1082 @@
+# Local Update Smoke Testing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a single `bin/smoke` command that exercises three user journeys (public pages, members login + gated content, WooCommerce add-to-cart through checkout-render) and tails the PHP error log, so the developer can confidently mirror a one-at-a-time local update to production.
+
+**Architecture:** A bash orchestrator (`bin/smoke`) wraps an idempotent WP-CLI fixture seeder (`bin/smoke-fixtures`) and a Playwright suite (`tests/smoke/specs/*.spec.ts`). Playwright runs Chromium against `http://localhost:${WP_PORT}` with `retries=0`. After the suite, the orchestrator pulls `docker compose logs wordpress --since=<start>` and fails the run on `PHP Fatal`/`PHP Parse`/`Uncaught` (or warnings/notices/deprecations under `--strict`).
+
+**Tech Stack:** Playwright (`@playwright/test`, already in devDependencies), Chromium, bash, WP-CLI via the `wpcli` Docker Compose service, Node ≥ 24.
+
+**Spec:** [`docs/superpowers/specs/2026-05-14-update-smoke-testing-design.md`](../specs/2026-05-14-update-smoke-testing-design.md)
+
+---
+
+## Prerequisites
+
+Before starting Task 1, the worktree must be able to run the site. Follow `README.md` "Pattern A — independent DB via stdin import" so this worktree has its own DB seeded from `db-backups/poweroffamilies.dump` and a symlinked `wordpress/` directory. The smoke suite will run against the worktree's own Docker stack on the port set in `.env`. Verify:
+
+```shell
+docker compose up -d wordpress
+curl -sS -o /dev/null -w '%{http_code}\n' "http://localhost:$(grep ^WP_PORT .env 2>/dev/null | cut -d= -f2 || echo 8080)/"
+# Expected: 200 (or 301/302 to the canonical URL — either is fine)
+```
+
+If you see anything else, fix it before continuing — every task below assumes a working local site.
+
+---
+
+## File Structure
+
+**Create:**
+- `bin/smoke` — orchestrator (bash, executable)
+- `bin/smoke-fixtures` — WP-CLI idempotent seeder (bash, executable)
+- `tests/smoke/playwright.config.ts`
+- `tests/smoke/fixtures.ts` — shared constants
+- `tests/smoke/specs/public-pages.spec.ts`
+- `tests/smoke/specs/login-gated.spec.ts`
+- `tests/smoke/specs/woo-checkout.spec.ts`
+
+**Modify:**
+- `package.json` — add `smoke`, `smoke:fixtures`, `smoke:install` scripts
+- `.gitignore` — add Playwright artifact dirs
+- `README.md` — add "Smoke Testing" section
+
+---
+
+## Task 1: Scaffold tests/smoke/ and install Chromium
+
+**Files:**
+- Create: `tests/smoke/playwright.config.ts`
+- Create: `tests/smoke/specs/placeholder.spec.ts` (temporary — deleted in Task 7)
+- Modify: `package.json`
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Add Playwright config**
+
+Create `tests/smoke/playwright.config.ts`:
+
+```ts
+import { defineConfig } from '@playwright/test';
+
+const wpPort = process.env.WP_PORT ?? '8080';
+
+export default defineConfig({
+    testDir: './specs',
+    fullyParallel: true,
+    forbidOnly: !!process.env.CI,
+    retries: 0,
+    workers: undefined,
+    reporter: 'list',
+    use: {
+        baseURL: `http://localhost:${wpPort}`,
+        trace: 'retain-on-failure',
+        screenshot: 'only-on-failure',
+        video: 'off',
+    },
+    projects: [
+        {
+            name: 'chromium',
+            use: { browserName: 'chromium' },
+        },
+    ],
+});
+```
+
+- [ ] **Step 2: Add placeholder spec so we can verify the runner**
+
+Create `tests/smoke/specs/placeholder.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test';
+
+test('placeholder — runner wiring sanity check', () => {
+    expect(1 + 1).toBe(2);
+});
+```
+
+- [ ] **Step 3: Add npm scripts**
+
+Open `package.json` and add these entries inside the existing `"scripts"` object (alongside `"test:docs"`):
+
+```json
+"smoke": "bin/smoke",
+"smoke:fixtures": "bin/smoke-fixtures",
+"smoke:install": "playwright install chromium"
+```
+
+- [ ] **Step 4: Add gitignore entries**
+
+Append to `.gitignore`:
+
+```
+# Smoke testing artifacts
+tests/smoke/test-results/
+tests/smoke/playwright-report/
+```
+
+- [ ] **Step 5: Install Chromium**
+
+Run: `npm run smoke:install`
+Expected: Chromium downloads (a few hundred MB on first run). On subsequent runs, "browser already installed".
+
+- [ ] **Step 6: Run the placeholder spec**
+
+Run: `npx playwright test --config tests/smoke/playwright.config.ts`
+Expected: `1 passed`.
+
+- [ ] **Step 7: Commit**
+
+```shell
+git add tests/smoke/playwright.config.ts tests/smoke/specs/placeholder.spec.ts package.json .gitignore
+git commit -m "Scaffold Playwright smoke runner under tests/smoke/"
+```
+
+---
+
+## Task 2: bin/smoke-fixtures — create test user idempotently
+
+**Files:**
+- Create: `bin/smoke-fixtures` (executable)
+
+The fixtures script grows incrementally over Tasks 2–5. Each task adds one fixture; running the script after every task should be idempotent (no errors on re-run).
+
+- [ ] **Step 1: Create the script skeleton**
+
+Create `bin/smoke-fixtures` with mode 755:
+
+```bash
+#!/usr/bin/env bash
+# Idempotently seed test fixtures for bin/smoke. Each fixture checks before
+# creating, so this script is safe to re-run.
+#
+# Emits KEY=value lines on stdout so bin/smoke can `eval` / export them as
+# env vars for the Playwright suite.
+set -euo pipefail
+
+SMOKE_USER_EMAIL="smoketest@example.com"
+SMOKE_USER_LOGIN="smoketest"
+SMOKE_PASSWORD="${SMOKE_PASSWORD:-smoke-test-pw-change-me}"
+
+wpcli() {
+    docker compose run --rm -T wpcli "$@"
+}
+
+ensure_user() {
+    if wpcli user get "$SMOKE_USER_EMAIL" --field=ID >/dev/null 2>&1; then
+        return 0
+    fi
+    wpcli user create "$SMOKE_USER_LOGIN" "$SMOKE_USER_EMAIL" \
+        --role=subscriber \
+        --user_pass="$SMOKE_PASSWORD" \
+        --display_name="Smoke Test" >/dev/null
+}
+
+ensure_user
+
+echo "SMOKE_USER_EMAIL=$SMOKE_USER_EMAIL"
+echo "SMOKE_USER_LOGIN=$SMOKE_USER_LOGIN"
+echo "SMOKE_PASSWORD=$SMOKE_PASSWORD"
+```
+
+Then: `chmod +x bin/smoke-fixtures`.
+
+- [ ] **Step 2: Run it once**
+
+Run: `bin/smoke-fixtures`
+Expected output (last three lines):
+
+```
+SMOKE_USER_EMAIL=smoketest@example.com
+SMOKE_USER_LOGIN=smoketest
+SMOKE_PASSWORD=smoke-test-pw-change-me
+```
+
+- [ ] **Step 3: Verify the user exists**
+
+Run: `docker compose run --rm -T wpcli user get smoketest@example.com`
+Expected: a table showing the user with role `subscriber`.
+
+- [ ] **Step 4: Run the script again to confirm idempotency**
+
+Run: `bin/smoke-fixtures`
+Expected: same output as Step 2, no errors, no duplicate user. Verify with:
+
+```shell
+docker compose run --rm -T wpcli user list --search=smoketest --format=count
+# Expected: 1
+```
+
+- [ ] **Step 5: Commit**
+
+```shell
+git add bin/smoke-fixtures
+git commit -m "Add smoke-fixtures script with idempotent test user creation"
+```
+
+---
+
+## Task 3: bin/smoke-fixtures — add WooCommerce test product
+
+**Files:**
+- Modify: `bin/smoke-fixtures`
+
+- [ ] **Step 1: Add the product fixture**
+
+In `bin/smoke-fixtures`, after the `ensure_user` function and before the `ensure_user` call, add:
+
+```bash
+SMOKE_PRODUCT_SLUG="smoke-test-product"
+SMOKE_PRODUCT_TITLE="Smoke Test Product"
+
+ensure_product() {
+    local existing
+    existing=$(wpcli post list \
+        --post_type=product \
+        --name="$SMOKE_PRODUCT_SLUG" \
+        --field=ID \
+        --format=ids 2>/dev/null | tr -d '[:space:]')
+    if [[ -n "$existing" ]]; then
+        return 0
+    fi
+    local id
+    id=$(wpcli post create \
+        --post_type=product \
+        --post_status=publish \
+        --post_title="$SMOKE_PRODUCT_TITLE" \
+        --post_name="$SMOKE_PRODUCT_SLUG" \
+        --porcelain)
+    # Make it a simple, purchasable product priced $1 with stock management off.
+    wpcli wc product update "$id" \
+        --type=simple \
+        --regular_price=1 \
+        --manage_stock=false \
+        --stock_status=instock \
+        --user=1 >/dev/null
+}
+```
+
+Then call `ensure_product` after the `ensure_user` call:
+
+```bash
+ensure_user
+ensure_product
+```
+
+And add a line to the printed output block:
+
+```bash
+echo "SMOKE_PRODUCT_SLUG=$SMOKE_PRODUCT_SLUG"
+```
+
+- [ ] **Step 2: Run and verify**
+
+Run: `bin/smoke-fixtures`
+Expected: clean exit, no errors. Output now includes `SMOKE_PRODUCT_SLUG=smoke-test-product`.
+
+Verify in the DB:
+
+```shell
+docker compose run --rm -T wpcli post list --post_type=product --name=smoke-test-product --format=count
+# Expected: 1
+docker compose run --rm -T wpcli wc product list --slug=smoke-test-product --field=price --user=1
+# Expected: "1.00"
+```
+
+- [ ] **Step 3: Re-run for idempotency**
+
+Run: `bin/smoke-fixtures` again. Verify count is still 1.
+
+- [ ] **Step 4: Commit**
+
+```shell
+git add bin/smoke-fixtures
+git commit -m "Add idempotent WooCommerce test product to smoke-fixtures"
+```
+
+---
+
+## Task 4: Resolve members-plugin gating mechanism
+
+This is a research task that resolves Open Question #1 from the spec. Output: a documented gating mechanism that Task 5 will use.
+
+**Files:**
+- No code changes yet — this is investigation.
+
+- [ ] **Step 1: List active members-related plugins**
+
+Run:
+
+```shell
+docker compose run --rm -T wpcli plugin list --status=active --format=csv | grep -iE 'member|group|paid|restrict|woo-membership'
+```
+
+Note which plugins are active.
+
+- [ ] **Step 2: Find an existing gated page on the site**
+
+Run:
+
+```shell
+docker compose run --rm -T wpcli post list --post_type=page --format=table --posts_per_page=50
+```
+
+Identify a page that you know is members-only. Get its ID, then inspect its content:
+
+```shell
+docker compose run --rm -T wpcli post get <ID> --field=post_content | head -80
+```
+
+Look for shortcodes like `[groups_member]`, `[members_access]`, `[ms-protect-content]`, or block markers like `<!-- wp:groups/restrict -->`. Whatever gates the content there is what we'll use for the smoke fixture.
+
+- [ ] **Step 3: Confirm by toggling logged-in state**
+
+In a browser (logged out), open the gated page — confirm gated content is hidden. Log in as any existing user with the gating role — confirm content appears. This proves the gating mechanism actually works on this install.
+
+- [ ] **Step 4: Determine the role/group the gating uses**
+
+If the plugin gates by role (e.g., the `members` plugin's "logged-in users can see" mode), the role we put on `smoketest` matters. If it gates by group membership (e.g., `groups` plugin), we'll need to add the user to a group in Task 5. Document the answer here in the plan comments, e.g. "Gates by group `Members`, group ID 42".
+
+- [ ] **Step 5: Record findings**
+
+Append a comment block to `bin/smoke-fixtures` documenting the decision:
+
+```bash
+# Members-plugin gating: <plugin name> gates content via <mechanism>.
+# Test fixture strategy: <how Task 5 will produce gated content visible to smoketest>.
+```
+
+Commit:
+
+```shell
+git add bin/smoke-fixtures
+git commit -m "Document smoke-test members-gating decision"
+```
+
+---
+
+## Task 5: bin/smoke-fixtures — add gated members page
+
+**Files:**
+- Modify: `bin/smoke-fixtures`
+
+The exact shortcode/block/role added below depends on Task 4's findings. The structure below assumes the common case: a `[shortcode]...[/shortcode]` wrapper that gates by role or membership. Adjust the `gated_content` heredoc to match your plugin's syntax.
+
+- [ ] **Step 1: Add the gated page fixture**
+
+Add to `bin/smoke-fixtures` after `ensure_product`:
+
+```bash
+SMOKE_GATED_SLUG="smoke-test-members-page"
+SMOKE_GATED_TITLE="Smoke Test Members Page"
+SMOKE_GATED_MARKER="MEMBERS_ONLY_MARKER"
+
+ensure_gated_page() {
+    local existing
+    existing=$(wpcli post list \
+        --post_type=page \
+        --name="$SMOKE_GATED_SLUG" \
+        --field=ID \
+        --format=ids 2>/dev/null | tr -d '[:space:]')
+    if [[ -n "$existing" ]]; then
+        return 0
+    fi
+    # IMPORTANT: replace the heredoc body with the gating syntax identified
+    # in Task 4. Example for the `groups` plugin:
+    #   [groups_member group="Members"]MEMBERS_ONLY_MARKER[/groups_member]
+    # Example for the `members` plugin:
+    #   [members_access role="subscriber"]MEMBERS_ONLY_MARKER[/members_access]
+    local gated_content
+    gated_content=$(cat <<EOF
+Public preamble visible to everyone.
+
+[REPLACE_WITH_GATING_SHORTCODE]
+$SMOKE_GATED_MARKER
+[/REPLACE_WITH_GATING_SHORTCODE]
+EOF
+)
+    wpcli post create \
+        --post_type=page \
+        --post_status=publish \
+        --post_title="$SMOKE_GATED_TITLE" \
+        --post_name="$SMOKE_GATED_SLUG" \
+        --post_content="$gated_content" >/dev/null
+}
+```
+
+Call it after `ensure_product`:
+
+```bash
+ensure_user
+ensure_product
+ensure_gated_page
+```
+
+If Task 4 determined the user must be added to a group, add a step inside `ensure_user` (or a new `ensure_user_group` function called after both `ensure_user` and `ensure_gated_page`) that joins the user to the group via WP-CLI — the exact command depends on the plugin.
+
+- [ ] **Step 2: Run the fixtures**
+
+Run: `bin/smoke-fixtures`
+Expected: clean exit, no errors.
+
+- [ ] **Step 3: Verify gating works manually**
+
+In a private/incognito browser window, visit `http://localhost:${WP_PORT}/smoke-test-members-page/` (or `/?page_id=<id>` if pretty permalinks aren't on). Expect: `MEMBERS_ONLY_MARKER` is NOT visible.
+
+Log in as `smoketest` / `smoke-test-pw-change-me`. Visit the page again. Expect: `MEMBERS_ONLY_MARKER` IS visible.
+
+If gating doesn't behave as expected, fix the shortcode/role in `bin/smoke-fixtures` before continuing — the Task 8 spec depends on this working.
+
+- [ ] **Step 4: Emit the gated slug**
+
+Add to the printed output block in `bin/smoke-fixtures`:
+
+```bash
+echo "SMOKE_GATED_SLUG=$SMOKE_GATED_SLUG"
+echo "SMOKE_GATED_MARKER=$SMOKE_GATED_MARKER"
+```
+
+- [ ] **Step 5: Re-run for idempotency**
+
+Run: `bin/smoke-fixtures` twice. Verify:
+
+```shell
+docker compose run --rm -T wpcli post list --post_type=page --name=smoke-test-members-page --format=count
+# Expected: 1
+```
+
+- [ ] **Step 6: Commit**
+
+```shell
+git add bin/smoke-fixtures
+git commit -m "Add idempotent gated members page to smoke-fixtures"
+```
+
+---
+
+## Task 6: bin/smoke-fixtures — emit latest-post and product URLs
+
+**Files:**
+- Modify: `bin/smoke-fixtures`
+
+- [ ] **Step 1: Add URL resolution**
+
+Add to `bin/smoke-fixtures` (after the `ensure_*` calls, before the `echo` block):
+
+```bash
+WP_PORT_LOCAL="${WP_PORT:-8080}"
+SITE_URL="http://localhost:${WP_PORT_LOCAL}"
+
+resolve_url() {
+    # $1 = post ID
+    wpcli post url "$1" 2>/dev/null
+}
+
+LATEST_POST_ID=$(wpcli post list \
+    --post_type=post \
+    --post_status=publish \
+    --posts_per_page=1 \
+    --field=ID \
+    --format=ids 2>/dev/null | tr -d '[:space:]')
+
+if [[ -z "$LATEST_POST_ID" ]]; then
+    echo "ERROR: no published posts found — public-pages spec needs one" >&2
+    exit 1
+fi
+
+PRODUCT_ID=$(wpcli post list \
+    --post_type=product \
+    --name="$SMOKE_PRODUCT_SLUG" \
+    --field=ID \
+    --format=ids 2>/dev/null | tr -d '[:space:]')
+GATED_ID=$(wpcli post list \
+    --post_type=page \
+    --name="$SMOKE_GATED_SLUG" \
+    --field=ID \
+    --format=ids 2>/dev/null | tr -d '[:space:]')
+
+SMOKE_LATEST_POST_URL=$(resolve_url "$LATEST_POST_ID")
+SMOKE_PRODUCT_URL=$(resolve_url "$PRODUCT_ID")
+SMOKE_GATED_URL=$(resolve_url "$GATED_ID")
+```
+
+- [ ] **Step 2: Replace the final echo block**
+
+Replace the trailing `echo` lines with:
+
+```bash
+cat <<EOF
+SMOKE_USER_EMAIL=$SMOKE_USER_EMAIL
+SMOKE_USER_LOGIN=$SMOKE_USER_LOGIN
+SMOKE_PASSWORD=$SMOKE_PASSWORD
+SMOKE_PRODUCT_SLUG=$SMOKE_PRODUCT_SLUG
+SMOKE_PRODUCT_URL=$SMOKE_PRODUCT_URL
+SMOKE_GATED_SLUG=$SMOKE_GATED_SLUG
+SMOKE_GATED_URL=$SMOKE_GATED_URL
+SMOKE_GATED_MARKER=$SMOKE_GATED_MARKER
+SMOKE_LATEST_POST_URL=$SMOKE_LATEST_POST_URL
+SITE_URL=$SITE_URL
+EOF
+```
+
+- [ ] **Step 3: Run and inspect**
+
+Run: `bin/smoke-fixtures`
+
+Expected: all `SMOKE_*` and `SITE_URL` keys printed, each with a non-empty value. The three URLs should resolve to fully-formed `http://localhost:${WP_PORT}/...` strings.
+
+If `SMOKE_LATEST_POST_URL` or `SMOKE_PRODUCT_URL` are empty, the corresponding post lookup failed — debug before continuing.
+
+- [ ] **Step 4: Commit**
+
+```shell
+git add bin/smoke-fixtures
+git commit -m "Resolve and emit smoke-fixture URLs"
+```
+
+---
+
+## Task 7: tests/smoke/fixtures.ts — shared spec constants
+
+**Files:**
+- Create: `tests/smoke/fixtures.ts`
+- Delete: `tests/smoke/specs/placeholder.spec.ts`
+
+- [ ] **Step 1: Create fixtures module**
+
+Create `tests/smoke/fixtures.ts`:
+
+```ts
+function required(name: string): string {
+    const value = process.env[name];
+    if (!value) {
+        throw new Error(
+            `Missing required env var: ${name}. Did bin/smoke-fixtures run before this spec?`,
+        );
+    }
+    return value;
+}
+
+export const env = {
+    siteUrl: required('SITE_URL'),
+    userEmail: required('SMOKE_USER_EMAIL'),
+    userLogin: required('SMOKE_USER_LOGIN'),
+    password: required('SMOKE_PASSWORD'),
+    productUrl: required('SMOKE_PRODUCT_URL'),
+    gatedUrl: required('SMOKE_GATED_URL'),
+    gatedMarker: required('SMOKE_GATED_MARKER'),
+    latestPostUrl: required('SMOKE_LATEST_POST_URL'),
+};
+
+// Strings WP renders when something blows up server-side.
+export const phpErrorMarkers = [
+    'Fatal error',
+    'Parse error',
+    'There has been a critical error on this website',
+];
+
+// Selectors that may need tweaking based on theme overrides. Centralized
+// here so spec churn happens in one file.
+export const selectors = {
+    // WP login form
+    loginUsername: '#user_login',
+    loginPassword: '#user_pass',
+    loginSubmit: '#wp-submit',
+    // WooCommerce — verified during Task 9 implementation.
+    addToCart: 'button[name="add-to-cart"], .single_add_to_cart_button',
+    cartSuccess: '.woocommerce-message, .wc-block-components-notice-banner',
+    checkoutForm: '.woocommerce-checkout, form.checkout',
+};
+```
+
+- [ ] **Step 2: Remove the placeholder spec**
+
+Delete `tests/smoke/specs/placeholder.spec.ts`.
+
+- [ ] **Step 3: Commit**
+
+```shell
+git add tests/smoke/fixtures.ts
+git rm tests/smoke/specs/placeholder.spec.ts
+git commit -m "Add shared fixtures module for smoke specs"
+```
+
+---
+
+## Task 8: public-pages.spec.ts
+
+**Files:**
+- Create: `tests/smoke/specs/public-pages.spec.ts`
+
+- [ ] **Step 1: Write the spec**
+
+Create `tests/smoke/specs/public-pages.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test';
+import { env, phpErrorMarkers } from '../fixtures';
+
+const urls: Array<{ name: string; url: string }> = [
+    { name: 'homepage', url: '/' },
+    { name: 'shop', url: '/shop/' },
+    { name: 'latest post', url: env.latestPostUrl },
+    { name: 'product', url: env.productUrl },
+];
+
+for (const { name, url } of urls) {
+    test(`${name} loads without PHP errors`, async ({ page }) => {
+        const response = await page.goto(url);
+        expect(response, `no response for ${url}`).not.toBeNull();
+        expect(response!.status(), `unexpected status for ${url}`).toBe(200);
+
+        const body = await page.content();
+        for (const marker of phpErrorMarkers) {
+            expect(
+                body.includes(marker),
+                `Found "${marker}" on ${url}`,
+            ).toBe(false);
+        }
+    });
+}
+```
+
+- [ ] **Step 2: Run it with the fixture env vars exported**
+
+Run:
+
+```shell
+eval "$(bin/smoke-fixtures | sed 's/^/export /')"
+npx playwright test --config tests/smoke/playwright.config.ts tests/smoke/specs/public-pages.spec.ts
+```
+
+Expected: `4 passed`.
+
+If a URL returns something other than 200 (e.g., 301), update the URL — `/shop` (no trailing slash) vs `/shop/` is a common gotcha, and `/shop/` is preferred to avoid the redirect counting as a non-200.
+
+- [ ] **Step 3: Commit**
+
+```shell
+git add tests/smoke/specs/public-pages.spec.ts
+git commit -m "Add public-pages smoke spec"
+```
+
+---
+
+## Task 9: woo-checkout.spec.ts
+
+**Files:**
+- Create: `tests/smoke/specs/woo-checkout.spec.ts`
+
+This task includes a selector-discovery step that resolves Open Question #2 from the spec.
+
+- [ ] **Step 1: Discover the actual Add-to-Cart selector**
+
+In the live site (any incognito window), visit the test product page. Open DevTools, find the Add-to-Cart button. Note:
+- Its `name` attribute (commonly `add-to-cart`)
+- Its CSS class (commonly `single_add_to_cart_button`)
+
+Click it manually and observe the success indicator that appears. Note its CSS class (commonly `.woocommerce-message`; the WooCommerce blocks-based cart uses `.wc-block-components-notice-banner` instead).
+
+If either differs from the defaults in `tests/smoke/fixtures.ts`, update that file accordingly and commit:
+
+```shell
+git add tests/smoke/fixtures.ts
+git commit -m "Pin Woo Add-to-Cart selectors in smoke fixtures"
+```
+
+- [ ] **Step 2: Write the spec**
+
+Create `tests/smoke/specs/woo-checkout.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test';
+import { env, phpErrorMarkers, selectors } from '../fixtures';
+
+test('add-to-cart through checkout render', async ({ page }) => {
+    await page.goto(env.productUrl);
+
+    await page.locator(selectors.addToCart).first().click();
+
+    await expect(
+        page.locator(selectors.cartSuccess).first(),
+        'cart success indicator did not appear',
+    ).toBeVisible({ timeout: 10_000 });
+
+    const checkoutResponse = await page.goto('/checkout/');
+    expect(checkoutResponse).not.toBeNull();
+    expect(checkoutResponse!.status()).toBe(200);
+
+    await expect(
+        page.locator(selectors.checkoutForm).first(),
+        'checkout form did not render',
+    ).toBeVisible({ timeout: 10_000 });
+
+    const body = await page.content();
+    for (const marker of phpErrorMarkers) {
+        expect(
+            body.includes(marker),
+            `Found "${marker}" on /checkout/`,
+        ).toBe(false);
+    }
+});
+```
+
+- [ ] **Step 3: Run it**
+
+Run:
+
+```shell
+eval "$(bin/smoke-fixtures | sed 's/^/export /')"
+npx playwright test --config tests/smoke/playwright.config.ts tests/smoke/specs/woo-checkout.spec.ts
+```
+
+Expected: `1 passed`. If it fails on the cart-success assertion, inspect `tests/smoke/test-results/` (screenshot + trace) and revisit selectors. If it fails on checkout-form, your install may use the WooCommerce blocks checkout — update `selectors.checkoutForm` to include a blocks-checkout selector like `.wp-block-woocommerce-checkout`.
+
+- [ ] **Step 4: Commit**
+
+```shell
+git add tests/smoke/specs/woo-checkout.spec.ts
+git commit -m "Add WooCommerce add-to-cart smoke spec"
+```
+
+---
+
+## Task 10: login-gated.spec.ts
+
+**Files:**
+- Create: `tests/smoke/specs/login-gated.spec.ts`
+
+- [ ] **Step 1: Write the spec**
+
+Create `tests/smoke/specs/login-gated.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test';
+import { env, selectors } from '../fixtures';
+
+test('gated members page hides marker when logged out, reveals when logged in', async ({
+    page,
+}) => {
+    // 1. Logged-out: marker must not appear.
+    await page.goto(env.gatedUrl);
+    await expect(page.locator('body'), 'gated content leaked to logged-out user').not.toContainText(
+        env.gatedMarker,
+    );
+
+    // 2. Log in via wp-login.php.
+    await page.goto('/wp-login.php');
+    await page.locator(selectors.loginUsername).fill(env.userLogin);
+    await page.locator(selectors.loginPassword).fill(env.password);
+    await Promise.all([page.waitForNavigation(), page.locator(selectors.loginSubmit).click()]);
+
+    // wp-login.php redirects to /wp-admin/ on success. If we landed elsewhere
+    // (e.g., back on the login page with an error), bail with a clear message.
+    expect(
+        page.url(),
+        `login redirect went somewhere unexpected: ${page.url()}`,
+    ).toMatch(/wp-admin|profile|members/);
+
+    // 3. Logged-in: marker must appear.
+    await page.goto(env.gatedUrl);
+    await expect(
+        page.locator('body'),
+        'gated content not visible to logged-in member',
+    ).toContainText(env.gatedMarker);
+});
+```
+
+- [ ] **Step 2: Run it**
+
+Run:
+
+```shell
+eval "$(bin/smoke-fixtures | sed 's/^/export /')"
+npx playwright test --config tests/smoke/playwright.config.ts tests/smoke/specs/login-gated.spec.ts
+```
+
+Expected: `1 passed`.
+
+If logged-in assertion fails, the gating shortcode in `bin/smoke-fixtures` doesn't recognize the role/group you assigned to `smoketest`. Revisit Task 4 / Task 5.
+
+- [ ] **Step 3: Commit**
+
+```shell
+git add tests/smoke/specs/login-gated.spec.ts
+git commit -m "Add members login + gated content smoke spec"
+```
+
+---
+
+## Task 11: bin/smoke — orchestrator
+
+**Files:**
+- Create: `bin/smoke` (executable)
+
+- [ ] **Step 1: Write the orchestrator**
+
+Create `bin/smoke` with mode 755:
+
+```bash
+#!/usr/bin/env bash
+# One-shot smoke test for after a plugin / theme / core update.
+#
+# Pipeline:
+#   1. Confirm the wordpress container is up.
+#   2. Record the docker-logs cutoff timestamp.
+#   3. Seed fixtures (idempotent) and export their identifiers.
+#   4. Run Playwright.
+#   5. Slice the wordpress container logs since the cutoff and check for
+#      PHP fatals / parse errors / uncaught exceptions. With --strict, also
+#      fail on warnings / notices / deprecations.
+#
+# Exits 0 only if Playwright passed AND the log slice is clean.
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+cd "$ROOT_DIR"
+
+STRICT=0
+for arg in "$@"; do
+    case "$arg" in
+        --strict) STRICT=1 ;;
+        -h|--help)
+            cat <<EOF
+Usage: bin/smoke [--strict]
+
+  --strict   also fail on PHP Warning / PHP Notice / Deprecated
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# 1. Container check.
+if ! docker compose ps --status=running --services 2>/dev/null | grep -qx wordpress; then
+    cat >&2 <<EOF
+wordpress container is not running. Bring it up first:
+
+    docker compose up -d wordpress
+
+EOF
+    exit 1
+fi
+
+# 2. Cutoff timestamp (RFC3339, UTC).
+SMOKE_LOG_SINCE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# 3. Seed fixtures and export their KEY=value output as env vars.
+echo "==> Seeding smoke fixtures…" >&2
+FIXTURES_OUT=$(bin/smoke-fixtures)
+while IFS= read -r line; do
+    [[ -z "$line" || "$line" != *=* ]] && continue
+    export "$line"
+done <<< "$FIXTURES_OUT"
+
+# 4. Run Playwright.
+echo "==> Running Playwright smoke suite…" >&2
+PLAYWRIGHT_EXIT=0
+npx playwright test --config tests/smoke/playwright.config.ts || PLAYWRIGHT_EXIT=$?
+
+# 5. Log slice.
+echo "==> Checking PHP error log since $SMOKE_LOG_SINCE…" >&2
+LOG_SLICE=$(docker compose logs wordpress --since="$SMOKE_LOG_SINCE" --no-color 2>&1 || true)
+
+if [[ "$STRICT" -eq 1 ]]; then
+    PATTERN='PHP Fatal|PHP Parse|Uncaught|PHP Warning|PHP Notice|Deprecated'
+else
+    PATTERN='PHP Fatal|PHP Parse|Uncaught'
+fi
+
+LOG_HITS=$(echo "$LOG_SLICE" | grep -E "$PATTERN" || true)
+LOG_EXIT=0
+if [[ -n "$LOG_HITS" ]]; then
+    LOG_EXIT=1
+    echo "==> PHP error log slice contained errors:" >&2
+    echo "$LOG_HITS" >&2
+fi
+
+if [[ "$PLAYWRIGHT_EXIT" -ne 0 || "$LOG_EXIT" -ne 0 ]]; then
+    echo "==> SMOKE FAILED (playwright=$PLAYWRIGHT_EXIT, log=$LOG_EXIT)" >&2
+    exit 1
+fi
+
+echo "==> SMOKE PASSED" >&2
+```
+
+Then: `chmod +x bin/smoke`.
+
+- [ ] **Step 2: Run it end-to-end**
+
+Run: `bin/smoke`
+Expected:
+- `==> Seeding smoke fixtures…`
+- `==> Running Playwright smoke suite…` → `6 passed` (4 public-pages + 1 login-gated + 1 woo-checkout)
+- `==> Checking PHP error log since …`
+- `==> SMOKE PASSED`
+- Exit code 0.
+
+Verify exit code: `echo $?` → `0`.
+
+- [ ] **Step 3: Confirm strict mode also passes (or doesn't, and that's informative)**
+
+Run: `bin/smoke --strict || true`
+
+If this passes, your install is clean. If it fails with notices/deprecations, that's the existing baseline — the failure output shows what's currently noisy, and re-running `bin/smoke --strict` after a future update will surface anything *new*. Don't fix the baseline noise; it's expected.
+
+- [ ] **Step 4: Confirm failure path works**
+
+Temporarily break a spec to confirm a failure produces useful output. In `tests/smoke/specs/public-pages.spec.ts`, change `/` to `/this-definitely-does-not-exist-9876/` and run `bin/smoke`. Expected: a failure naming the test, a screenshot/trace in `tests/smoke/test-results/`, exit code 1.
+
+Revert the change:
+
+```shell
+git checkout tests/smoke/specs/public-pages.spec.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```shell
+git add bin/smoke
+git commit -m "Add bin/smoke orchestrator with PHP error log tail"
+```
+
+---
+
+## Task 12: README — Smoke Testing section
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add the section**
+
+Open `README.md` and insert this as a new section under `## Ongoing Development`, after the existing `### Build Everything` block and before `## Miscellaneous`:
+
+````markdown
+### Smoke Testing After Updates
+
+`bin/smoke` exercises the public site, members login + gated content, and
+the WooCommerce add-to-cart → checkout-render flow, then tails the
+WordPress container's PHP error log. Run it after each local plugin /
+theme / core update; only mirror an update to production once it's green.
+
+**One-time setup (per worktree, after first checkout):**
+
+```shell
+npm run smoke:install   # downloads Chromium
+```
+
+**Discovering pending updates:**
+
+```shell
+docker compose run --rm wpcli plugin list --update=available
+docker compose run --rm wpcli theme list --update=available
+docker compose run --rm wpcli core check-update
+```
+
+These commands print every plugin/theme/core update available — no slug
+list to maintain.
+
+**The update loop:**
+
+```shell
+# 1. Update one thing locally
+docker compose run --rm wpcli plugin update <slug>   # or theme update / core update
+
+# 2. Smoke test
+npm run smoke
+
+# 3. If green, mirror to prod
+ssh pof 'wp plugin update <slug>'   # or however remote WP-CLI is invoked
+
+# 4. If red, revert locally
+docker compose run --rm wpcli plugin install <slug> --version=<previous> --force
+```
+
+The smoke suite is plugin-agnostic — it never sees which plugin was just
+updated. Run it after any single update. Use `npm run smoke -- --strict`
+to also fail on PHP warnings / notices / deprecated calls.
+
+Test fixtures (a `smoketest@example.com` user, a `Smoke Test Product`,
+and a gated members page) are seeded idempotently by `bin/smoke-fixtures`
+on every run; no manual setup needed beyond `npm run smoke:install`.
+````
+
+- [ ] **Step 2: Verify the rendered Markdown**
+
+Skim the section in a Markdown preview (VS Code's preview, GitHub's web view of the worktree branch, or `glow`). Confirm:
+- Code blocks are fenced correctly.
+- The discovery + loop commands are easy to scan.
+- The first-run setup is unambiguous.
+
+- [ ] **Step 3: Commit**
+
+```shell
+git add README.md
+git commit -m "Document smoke testing workflow in README"
+```
+
+---
+
+## Task 13: Final end-to-end verification
+
+**Files:**
+- No code changes.
+
+- [ ] **Step 1: Clean slate run**
+
+From a freshly-running stack:
+
+```shell
+docker compose up -d wordpress
+npm run smoke
+```
+
+Expected: `==> SMOKE PASSED`, exit code 0.
+
+- [ ] **Step 2: Confirm fixtures aren't duplicated**
+
+```shell
+docker compose run --rm -T wpcli user list --search=smoketest --format=count
+docker compose run --rm -T wpcli post list --post_type=product --name=smoke-test-product --format=count
+docker compose run --rm -T wpcli post list --post_type=page --name=smoke-test-members-page --format=count
+```
+
+Each: `1`.
+
+- [ ] **Step 3: Simulate an update + smoke cycle**
+
+Pick a low-risk plugin currently showing an available update (or use `--dry-run` if WP-CLI supports it for the chosen subcommand). Run:
+
+```shell
+docker compose run --rm wpcli plugin list --update=available
+docker compose run --rm wpcli plugin update <slug>
+npm run smoke
+```
+
+Expected: smoke green, you'd be confident mirroring that update to prod.
+
+- [ ] **Step 4: Confirm artifacts are gitignored**
+
+```shell
+git status
+```
+
+Expected: `tests/smoke/test-results/` and `tests/smoke/playwright-report/` (if they exist after the runs) do NOT appear as untracked files.
+
+- [ ] **Step 5: No commit needed unless something needed fixing**
+
+If you found and fixed issues during this task, commit them with a single `Final verification fixes` commit. Otherwise this task ends with no new commit.
+
+---
+
+## Done criteria
+
+- `npm run smoke` produces `==> SMOKE PASSED` on a freshly-running stack against the current set of installed plugins.
+- A deliberately broken spec produces clear failure output with a screenshot + trace in `tests/smoke/test-results/`.
+- `npm run smoke -- --strict` either passes or, on failure, shows the existing baseline noise (this is informative, not actionable).
+- Running `bin/smoke-fixtures` twice in a row leaves the DB in the same state (idempotent).
+- README documents discovery + update loop, and any developer can run `npm run smoke:install && npm run smoke` from a fresh worktree checkout (assuming Pattern A DB setup) without further instructions.

--- a/docs/superpowers/specs/2026-05-14-update-smoke-testing-design.md
+++ b/docs/superpowers/specs/2026-05-14-update-smoke-testing-design.md
@@ -1,0 +1,178 @@
+# Local Smoke Testing for Plugin / Theme / Core Updates
+
+**Status:** Approved (design only — implementation in a follow-up plan)
+**Date:** 2026-05-14
+**Author:** Jared Loosli (with Claude)
+
+## Problem
+
+Production plugins, the Genesis parent theme, and WordPress core periodically need updating. Doing those updates blind on production risks breaking the public site (homepage, blog), the WooCommerce buy flow, or the gated members area. We want to apply each update *locally first*, prove the site still works, and only then mirror the same update to production via WP-CLI — one update at a time, so any breakage is unambiguously attributable.
+
+The repo already has Docker-based local WordPress and PHPUnit unit tests for the custom theme/plugin, but no automated way to verify that the *integrated* site still functions after a third-party plugin update. That gap is what this spec fills.
+
+## Goals
+
+- One command (`bin/smoke`) verifies the local site after any update.
+- Covers three user journeys: public pages loading, members login + gated content, WooCommerce add-to-cart through checkout-page render.
+- Catches PHP fatals and uncaught exceptions even when a page returns HTTP 200.
+- Idempotent test fixtures — no leaning on real customer data.
+- Works unchanged in any worktree (no hardcoded ports).
+
+## Non-Goals
+
+- No CI integration. The trigger is the developer's local update workflow.
+- No visual regression / screenshot diffing.
+- No `wp-admin` smoke tests (admin fatals surface immediately when `wp plugin update` runs).
+- No actual order placement. The WooCommerce smoke test stops at checkout-page render.
+- No automated mirroring of updates to production. The developer continues running `wp plugin update` against prod manually.
+- No coverage of the ~25 other plugins beyond what the three journeys exercise transitively.
+- No retry/flake handling — `retries=0`. Bump later if it becomes annoying.
+
+## Workflow this enables
+
+```shell
+# 1. Update one plugin locally
+docker compose exec wpcli wp plugin update <plugin-slug>
+
+# 2. Smoke test
+bin/smoke
+
+# 3. If green, mirror to prod
+ssh pof 'wp plugin update <plugin-slug>'   # or however remote WP-CLI is invoked
+
+# 4. If red, revert locally and investigate
+docker compose exec wpcli wp plugin install <plugin-slug> --version=<previous> --force
+```
+
+The same flow applies to Genesis parent-theme updates (`wp theme update genesis`) and WordPress core updates (`wp core update`).
+
+We deliberately do **not** wrap steps 1–3 into a single helper. Keeping the update step explicit reinforces the "one at a time" discipline.
+
+## Architecture
+
+### File layout
+
+```
+power-of-families/
+├── bin/
+│   ├── smoke                    # one-shot entry: fixtures → playwright → log check → exit code
+│   └── smoke-fixtures           # WP-CLI seeding, idempotent
+├── tests/
+│   └── smoke/
+│       ├── playwright.config.ts # baseURL from $WP_PORT, single project, retries=0
+│       ├── fixtures.ts          # shared selectors + credentials constants
+│       └── specs/
+│           ├── public-pages.spec.ts
+│           ├── login-gated.spec.ts
+│           └── woo-checkout.spec.ts
+└── package.json                 # adds "smoke", "smoke:fixtures", "smoke:install"
+```
+
+Smoke tests live under `tests/smoke/`, not the theme's `tests/`, because they're whole-site integration tests rather than theme unit tests.
+
+### Components
+
+**`bin/smoke`** — the entry point. Bash script. Responsibilities:
+1. Verify the `wordpress` container is up (`docker compose ps wordpress`); exit with a helpful message if not.
+2. Record the PHP error log start position (see *PHP error log tail* below).
+3. Run `bin/smoke-fixtures` and capture the emitted `SMOKE_USER_EMAIL`, `SMOKE_GATED_URL`, `SMOKE_PRODUCT_URL`, `SMOKE_LATEST_POST_URL`.
+4. Run `npx playwright test --config tests/smoke/playwright.config.ts` with those values in the environment.
+5. Slice the PHP error log from the recorded start point and check for new fatals/uncaught exceptions.
+6. Exit 0 only if Playwright passed AND the log slice is clean. Otherwise print the relevant failures and exit non-zero.
+
+**`bin/smoke-fixtures`** — idempotent WP-CLI seeding. Each step checks before creating:
+1. **Test member user** — email `smoketest@example.com`, role `subscriber` (or whichever role gates members content; resolved during implementation by inspecting an existing gated page). Password read from env `SMOKE_PASSWORD`, defaulting to a documented dev value. `wp user get smoketest@example.com` first; only `wp user create` if it 404s.
+2. **Test gated page** — title `Smoke Test Members Page`, slug fixed, body contains the literal string `MEMBERS_ONLY_MARKER` wrapped in whatever members-plugin gate the site uses. The login spec asserts the marker is absent pre-login and present post-login.
+3. **Test WooCommerce product** — title `Smoke Test Product`, slug `smoke-test-product`, type `simple`, price `$1`, status `publish`, stock management off so it's always purchasable.
+4. Resolves the latest published post's permalink (`wp post list --post_type=post --posts_per_page=1` combined with `wp option get permalink_structure` to produce a fully-formed URL).
+5. Prints the resolved identifiers and URLs to stdout in `KEY=value` form so `bin/smoke` can export them as env vars for Playwright: `SMOKE_USER_EMAIL`, `SMOKE_GATED_URL`, `SMOKE_PRODUCT_URL`, `SMOKE_LATEST_POST_URL`.
+
+**`tests/smoke/playwright.config.ts`** — minimal config:
+- `baseURL` = `http://localhost:${process.env.WP_PORT ?? 8080}` so worktrees with their own ports work unchanged.
+- Single project (Chromium only — additional browsers add time without catching more WP-plugin breakage).
+- `retries: 0`.
+- Reporter: `list` for terminal output.
+- Artifacts: screenshots + trace on failure, written to `tests/smoke/test-results/` (gitignored).
+
+**`tests/smoke/fixtures.ts`** — module-level constants for credentials, selectors, and URL paths. Keeps specs free of magic strings and concentrates the inevitable selector churn in one file.
+
+### The three specs
+
+**`public-pages.spec.ts`** — one test per URL, parallel:
+- `/` (homepage)
+- `SMOKE_LATEST_POST_URL` (latest published post)
+- `/shop/`
+- `SMOKE_PRODUCT_URL` (the seeded `smoke-test-product`)
+
+Each test: `goto(url)`, assert response status is 200, assert the page body does *not* contain `Fatal error`, `Warning:`, `Notice:`, `Parse error`, or the WP user-facing critical-error string `There has been a critical error on this website`.
+
+**`login-gated.spec.ts`** — single test:
+1. `goto(SMOKE_GATED_URL)` — assert `MEMBERS_ONLY_MARKER` is NOT visible (gating works).
+2. Log in via the `/wp-login.php` form using `SMOKE_USER_EMAIL` + `SMOKE_PASSWORD`.
+3. `goto(SMOKE_GATED_URL)` again — assert `MEMBERS_ONLY_MARKER` IS visible.
+
+**`woo-checkout.spec.ts`** — single test:
+1. `goto(SMOKE_PRODUCT_URL)`, click the Add-to-Cart button.
+2. Assert the cart's success notice or count badge (selector lives in `fixtures.ts`).
+3. `goto(/checkout/)`, assert a stable checkout-page element (e.g. `#payment` or `.woocommerce-checkout`) renders.
+4. Stop. No order placement.
+
+### PHP error log tail
+
+Catches "page returned 200 but threw a warning" — the failure mode that pure HTTP-status checks miss.
+
+**Source:** `docker compose logs wordpress --since=<start-timestamp>`. This is preferred over `wp-content/debug.log` because it works without flipping `WP_DEBUG_LOG` and doesn't require a container restart. Noise from other requests is filtered with grep patterns. `bin/smoke` captures a UTC timestamp before tests start; after tests complete, it pulls the log slice since that timestamp.
+
+**Patterns matched (default):**
+- `PHP Fatal`
+- `PHP Parse`
+- `Uncaught`
+
+**Patterns matched with `--strict`:** the above plus
+- `PHP Warning`
+- `PHP Notice`
+- `Deprecated`
+
+Default omits warnings/notices because a production WordPress site with 30 plugins typically has a baseline of harmless third-party deprecations; making the default run fail on those would train the developer to ignore the signal. `--strict` is for when you specifically want to inspect what a plugin update added to that baseline.
+
+### Worktree compatibility
+
+`bin/smoke` reads `WP_PORT` from the worktree's `.env` (via `docker compose` env loading) or falls back to `8080`. Each worktree's smoke run hits its own stack on its own host port. Fixtures are seeded into whichever DB the worktree is pointing at (Pattern A/B/C from `README.md`), so a worktree using the live-shared DB will see the fixtures in main's data — acceptable since the fixtures use distinctive identifiers.
+
+## Failure handling
+
+On failure the developer gets:
+
+- Playwright `list` reporter output naming each failed spec + the failing assertion.
+- Per-failed-test artifacts in `tests/smoke/test-results/<spec-name>/`:
+  - PNG screenshot at the point of failure
+  - Full Playwright trace (`trace.zip`, openable with `npx playwright show-trace`)
+  - The page HTML at failure time
+- If the PHP error log slice triggered the failure, the matching log lines are printed inline.
+- Non-zero exit code (composes with `&&` if scripted).
+
+Gitignored: `tests/smoke/test-results/`, `tests/smoke/playwright-report/`, Playwright's browser cache.
+
+## Developer ergonomics
+
+**Package.json scripts:**
+- `npm run smoke` → `bin/smoke`
+- `npm run smoke:fixtures` → `bin/smoke-fixtures` (rarely needed standalone)
+- `npm run smoke:install` → `npx playwright install chromium` (one-time browser download)
+
+**README addition:** a "Smoke Testing" section under "Ongoing Development" with the first-run setup (`npm run smoke:install`) and the update loop documented above.
+
+## Open questions resolved during implementation
+
+These don't block writing the implementation plan but need answers before code lands:
+
+1. **Which members plugin gates the content** — `members`, `groups`, or another. The repo has all three installed. Resolution: inspect an existing gated page on local to identify the active gating mechanism, then have `bin/smoke-fixtures` use the matching shortcode/block/role.
+2. **Add-to-Cart success selector** — depends on the active theme's WooCommerce template overrides. Resolution: load the local product page in a browser, observe the post-click DOM, and pin a stable selector in `fixtures.ts`.
+
+## Future work (out of scope here)
+
+- Visual regression via Playwright screenshot comparison, once a baseline is established.
+- A `--deep` flag that places a real test order through the WooCommerce "Cash on Delivery" gateway, for catching breakage in the order-creation path.
+- `wp-admin` smoke (load dashboard, plugins page, post editor).
+- CI integration that gates prod-syncs on a green local smoke run.
+- A `bin/update-and-smoke <plugin>` wrapper, *only if* the explicit-step boundary stops being valuable.

--- a/docs/superpowers/specs/2026-05-14-update-smoke-testing-design.md
+++ b/docs/superpowers/specs/2026-05-14-update-smoke-testing-design.md
@@ -111,7 +111,7 @@ Smoke tests live under `tests/smoke/`, not the theme's `tests/`, because they're
 - `/shop/`
 - `SMOKE_PRODUCT_URL` (the seeded `smoke-test-product`)
 
-Each test: `goto(url)`, assert response status is 200, assert the page body does *not* contain `Fatal error`, `Warning:`, `Notice:`, `Parse error`, or the WP user-facing critical-error string `There has been a critical error on this website`.
+Each test: `goto(url)`, assert response status is 200, assert the page body does *not* contain `Fatal error`, `Parse error`, or the WP user-facing critical-error string `There has been a critical error on this website`. Warnings, notices, and deprecations are deliberately *not* asserted in the body — they're caught (when you want them) by the PHP error log tail's `--strict` mode in the next section, so the default smoke run doesn't fail on the baseline notice noise that a 30-plugin WP install typically carries.
 
 **`login-gated.spec.ts`** — single test:
 1. `goto(SMOKE_GATED_URL)` — assert `MEMBERS_ONLY_MARKER` is NOT visible (gating works).

--- a/docs/superpowers/specs/2026-05-14-update-smoke-testing-design.md
+++ b/docs/superpowers/specs/2026-05-14-update-smoke-testing-design.md
@@ -31,6 +31,11 @@ The repo already has Docker-based local WordPress and PHPUnit unit tests for the
 ## Workflow this enables
 
 ```shell
+# 0. Discover what's pending (no separate slug list to maintain)
+docker compose exec wpcli wp plugin list --update=available
+docker compose exec wpcli wp theme list --update=available
+docker compose exec wpcli wp core check-update
+
 # 1. Update one plugin locally
 docker compose exec wpcli wp plugin update <plugin-slug>
 
@@ -45,6 +50,8 @@ docker compose exec wpcli wp plugin install <plugin-slug> --version=<previous> -
 ```
 
 The same flow applies to Genesis parent-theme updates (`wp theme update genesis`) and WordPress core updates (`wp core update`).
+
+The smoke suite itself is plugin-agnostic — it never sees the slug of the plugin you just updated. It exercises user journeys and tails the PHP error log, so it catches breakage from any update.
 
 We deliberately do **not** wrap steps 1–3 into a single helper. Keeping the update step explicit reinforces the "one at a time" discipline.
 
@@ -160,7 +167,10 @@ Gitignored: `tests/smoke/test-results/`, `tests/smoke/playwright-report/`, Playw
 - `npm run smoke:fixtures` → `bin/smoke-fixtures` (rarely needed standalone)
 - `npm run smoke:install` → `npx playwright install chromium` (one-time browser download)
 
-**README addition:** a "Smoke Testing" section under "Ongoing Development" with the first-run setup (`npm run smoke:install`) and the update loop documented above.
+**README addition:** a "Smoke Testing" section under "Ongoing Development" containing:
+- First-run setup (`npm run smoke:install`).
+- The discovery commands (`wp plugin list --update=available`, `wp theme list --update=available`, `wp core check-update`) so the developer can see at a glance what needs updating without remembering the WP-CLI syntax.
+- The full update loop (discover → update locally → smoke → mirror to prod or revert) documented in the *Workflow this enables* section above.
 
 ## Open questions resolved during implementation
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,10 @@
 		"test:dev-helper": "bin/test-dev-helper.sh",
 		"test:env-manager": "bin/test-env-manager.sh",
 		"test:performance": "bin/test-performance-monitor.sh",
-		"test:docs": "bin/test-docs.sh"
+		"test:docs": "bin/test-docs.sh",
+		"smoke": "bin/smoke",
+		"smoke:fixtures": "bin/smoke-fixtures",
+		"smoke:install": "playwright install chromium"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.55.0",

--- a/tests/smoke/fixtures.ts
+++ b/tests/smoke/fixtures.ts
@@ -1,0 +1,40 @@
+function required(name: string): string {
+	const value = process.env[name];
+	if (!value) {
+		throw new Error(
+			`Missing required env var: ${name}. Did bin/smoke-fixtures run before this spec?`
+		);
+	}
+	return value;
+}
+
+export const env = {
+	siteUrl: required('SITE_URL'),
+	userEmail: required('SMOKE_USER_EMAIL'),
+	userLogin: required('SMOKE_USER_LOGIN'),
+	password: required('SMOKE_PASSWORD'),
+	productUrl: required('SMOKE_PRODUCT_URL'),
+	gatedUrl: required('SMOKE_GATED_URL'),
+	gatedMarker: required('SMOKE_GATED_MARKER'),
+	latestPostUrl: required('SMOKE_LATEST_POST_URL'),
+};
+
+// Strings WP renders when something blows up server-side.
+export const phpErrorMarkers = [
+	'Fatal error',
+	'Parse error',
+	'There has been a critical error on this website',
+];
+
+// Selectors that may need tweaking based on theme overrides. Centralized
+// here so spec churn happens in one file.
+export const selectors = {
+	// WP login form
+	loginUsername: '#user_login',
+	loginPassword: '#user_pass',
+	loginSubmit: '#wp-submit',
+	// WooCommerce — verified during Task 9 implementation.
+	addToCart: 'button[name="add-to-cart"], .single_add_to_cart_button',
+	cartSuccess: '.woocommerce-message, .wc-block-components-notice-banner',
+	checkoutForm: '.woocommerce-checkout, form.checkout',
+};

--- a/tests/smoke/playwright.config.ts
+++ b/tests/smoke/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from '@playwright/test';
+
+const wpPort = process.env.WP_PORT ?? '8080';
+
+export default defineConfig({
+    testDir: './specs',
+    fullyParallel: true,
+    forbidOnly: !!process.env.CI,
+    retries: 0,
+    workers: undefined,
+    reporter: 'list',
+    use: {
+        baseURL: `http://localhost:${wpPort}`,
+        trace: 'retain-on-failure',
+        screenshot: 'only-on-failure',
+        video: 'off',
+    },
+    projects: [
+        {
+            name: 'chromium',
+            use: { browserName: 'chromium' },
+        },
+    ],
+});

--- a/tests/smoke/playwright.config.ts
+++ b/tests/smoke/playwright.config.ts
@@ -3,22 +3,22 @@ import { defineConfig } from '@playwright/test';
 const wpPort = process.env.WP_PORT ?? '8080';
 
 export default defineConfig({
-    testDir: './specs',
-    fullyParallel: true,
-    forbidOnly: !!process.env.CI,
-    retries: 0,
-    workers: undefined,
-    reporter: 'list',
-    use: {
-        baseURL: `http://localhost:${wpPort}`,
-        trace: 'retain-on-failure',
-        screenshot: 'only-on-failure',
-        video: 'off',
-    },
-    projects: [
-        {
-            name: 'chromium',
-            use: { browserName: 'chromium' },
-        },
-    ],
+	testDir: './specs',
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: 0,
+	workers: undefined,
+	reporter: 'list',
+	use: {
+		baseURL: `http://localhost:${wpPort}`,
+		trace: 'retain-on-failure',
+		screenshot: 'only-on-failure',
+		video: 'off',
+	},
+	projects: [
+		{
+			name: 'chromium',
+			use: { browserName: 'chromium' },
+		},
+	],
 });

--- a/tests/smoke/specs/login-gated.spec.ts
+++ b/tests/smoke/specs/login-gated.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+import { env, selectors } from '../fixtures';
+
+test('gated members page is hidden when logged out, visible when logged in', async ({
+	page,
+}) => {
+	// 1. Logged-out: groups plugin returns a hard 404 for gated pages.
+	const anonResponse = await page.goto(env.gatedUrl);
+	expect(anonResponse).not.toBeNull();
+	expect(
+		anonResponse!.status(),
+		'gated page should 404 for logged-out users'
+	).toBe(404);
+
+	// 2. Log in via wp-login.php.
+	await page.goto('/wp-login.php');
+	await page.locator(selectors.loginUsername).fill(env.userLogin);
+	await page.locator(selectors.loginPassword).fill(env.password);
+	await Promise.all([
+		page.waitForNavigation(),
+		page.locator(selectors.loginSubmit).click(),
+	]);
+
+	// wp-login.php redirects to /wp-admin/ on success. Bail with a clear
+	// message if we landed back on the login page (indicating bad creds).
+	expect(
+		page.url(),
+		`login redirect went somewhere unexpected: ${page.url()}`
+	).toMatch(/wp-admin|profile|members|my-account/);
+
+	// 3. Logged-in: marker must appear in the gated page body.
+	const memberResponse = await page.goto(env.gatedUrl);
+	expect(memberResponse!.status()).toBe(200);
+	await expect(
+		page.locator('body'),
+		'gated content not visible to logged-in member'
+	).toContainText(env.gatedMarker);
+});

--- a/tests/smoke/specs/placeholder.spec.ts
+++ b/tests/smoke/specs/placeholder.spec.ts
@@ -1,0 +1,5 @@
+import { test, expect } from '@playwright/test';
+
+test('placeholder — runner wiring sanity check', () => {
+    expect(1 + 1).toBe(2);
+});

--- a/tests/smoke/specs/placeholder.spec.ts
+++ b/tests/smoke/specs/placeholder.spec.ts
@@ -1,5 +1,0 @@
-import { test, expect } from '@playwright/test';
-
-test('placeholder — runner wiring sanity check', () => {
-	expect(1 + 1).toBe(2);
-});

--- a/tests/smoke/specs/placeholder.spec.ts
+++ b/tests/smoke/specs/placeholder.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
 
 test('placeholder — runner wiring sanity check', () => {
-    expect(1 + 1).toBe(2);
+	expect(1 + 1).toBe(2);
 });

--- a/tests/smoke/specs/public-pages.spec.ts
+++ b/tests/smoke/specs/public-pages.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+import { env, phpErrorMarkers } from '../fixtures';
+
+const urls: Array<{ name: string; url: string }> = [
+	{ name: 'homepage', url: '/' },
+	{ name: 'shop', url: '/shop/' },
+	{ name: 'latest post', url: env.latestPostUrl },
+	{ name: 'product', url: env.productUrl },
+];
+
+for (const { name, url } of urls) {
+	test(`${name} loads without PHP errors`, async ({ page }) => {
+		const response = await page.goto(url);
+		expect(response, `no response for ${url}`).not.toBeNull();
+		expect(response!.status(), `unexpected status for ${url}`).toBe(200);
+
+		const body = await page.content();
+		for (const marker of phpErrorMarkers) {
+			expect(body.includes(marker), `Found "${marker}" on ${url}`).toBe(
+				false
+			);
+		}
+	});
+}

--- a/tests/smoke/specs/woo-checkout.spec.ts
+++ b/tests/smoke/specs/woo-checkout.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+import { env, phpErrorMarkers, selectors } from '../fixtures';
+
+test('add-to-cart through checkout render', async ({ page }) => {
+	await page.goto(env.productUrl);
+
+	await page.locator(selectors.addToCart).first().click();
+
+	await expect(
+		page.locator(selectors.cartSuccess).first(),
+		'cart success indicator did not appear'
+	).toBeVisible({ timeout: 10_000 });
+
+	const checkoutResponse = await page.goto('/checkout/');
+	expect(checkoutResponse).not.toBeNull();
+	expect(checkoutResponse!.status()).toBe(200);
+
+	await expect(
+		page.locator(selectors.checkoutForm).first(),
+		'checkout form did not render'
+	).toBeVisible({ timeout: 10_000 });
+
+	const body = await page.content();
+	for (const marker of phpErrorMarkers) {
+		expect(body.includes(marker), `Found "${marker}" on /checkout/`).toBe(
+			false
+		);
+	}
+});


### PR DESCRIPTION
## Summary

- New `bin/smoke` command runs after each local plugin / theme / core update and reports green-or-red before mirroring the update to production.
- Three Playwright specs (6 tests) cover the three user journeys we'd really regret breaking: public pages, members login + gated content, and WooCommerce add-to-cart → checkout-render.
- A PHP-error-log tail (`docker compose logs wordpress --since=…`) catches fatals/parse errors/uncaught exceptions even when a page returns 200; `--strict` also catches warnings/notices/deprecations.
- Test fixtures (a `smoketest@example.com` user, a `Smoke Test Product`, and a gated members page) are seeded idempotently by `bin/smoke-fixtures` — no manual setup beyond a one-time `npm run smoke:install`.

## Workflow this enables

```shell
# Discover pending updates (no slug list to maintain)
docker compose run --rm wpcli plugin list --update=available

# Update one thing locally, smoke test, mirror to prod on green
docker compose run --rm wpcli plugin update <slug>
npm run smoke
ssh pof 'wp plugin update <slug>'
```

## Notable adaptations during implementation

- The `groups` plugin (not `members`) is what gates content on this site, via `groups-read` postmeta — anonymous visitors get a hard 404, not a "members only" placeholder. Documented in `bin/smoke-fixtures` comment block.
- `wp post list --name=` doesn't see gated pages (the groups plugin filters them from WP-CLI queries). Use `wpcli eval` + `$wpdb->prepare()` instead.
- `wp post url` returns production-domain URLs; a `local_url()` helper in `bin/smoke-fixtures` rewrites the path onto the local `SITE_URL`.
- `woocommerce_force_ssl_checkout` was on, redirecting `/checkout/` to `https://localhost:8081/...` which has no listener. `bin/smoke-fixtures` flips it off idempotently (noted in README — persistent side effect on the local DB).
- The `wordpress:cli` Docker image defaults to PHP `memory_limit=128M`, which OOMs at boot under the full plugin set (Jetpack + WooCommerce + members). A new `docker/wp-cli.ini` mounted into the wpcli service bumps it to 512M.

## Design + plan docs

- Spec: `docs/superpowers/specs/2026-05-14-update-smoke-testing-design.md`
- Plan: `docs/superpowers/plans/2026-05-14-update-smoke-testing.md`

## Test plan

- [ ] `npm run smoke:install` succeeds on a fresh checkout (downloads Chromium)
- [ ] `npm run smoke` produces `==> SMOKE PASSED` and exits 0 against the current plugin set
- [ ] `npm run smoke -- --strict` either passes or fails informatively (existing baseline noise is acceptable; a successful local run had it pass cleanly)
- [ ] `bin/smoke-fixtures` is idempotent — counts stay at 1 for user, product, gated page after multiple runs
- [ ] A deliberately-broken spec produces a failure with screenshot + trace in `tests/smoke/test-results/` and exit code 1
- [ ] After applying a real plugin update locally, smoke run still passes (try a low-risk one from `wp plugin list --update=available`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)