### PR TITLE
Ignore local Claude Code skill installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ db-backups
 # Claude Code (local settings + worktree mirrors under .claude/worktrees/)
 .claude/
 
+# Local Claude Code skill installs (mattpocock/skills etc.)
+.agents/
+skills-lock.json
+
 # Logs
 logs
 *.log


### PR DESCRIPTION
## Summary
- Add `.agents/` and `skills-lock.json` to `.gitignore` so personal Claude Code skill installs (e.g. from `mattpocock/skills`) don't show up as untracked in shared checkouts.

## Test plan
- [ ] `git status` in a checkout with `.agents/` and `skills-lock.json` present shows no untracked entries for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)