### PR TITLE
Add .prettierignore for vendored and generated files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,16 @@
+# Prettier reads both .gitignore and .prettierignore by default, so build
+# output and untracked dirs (wordpress, coverage, test-reports, db-data) are
+# already excluded. This file covers tracked files we deliberately don't format.
+
+# Vendored third-party code — upstream copies, keep byte-identical so they
+# stay diffable against their source releases.
+wp-content/themes/power-of-families/bootstrap
+wp-content/plugins/pof-bloom-plugin/assets/js/jQuery.dotdotdot-master
+
+# Minified builds
+*.min.js
+*.min.css
+
+# Generated lockfiles
+package-lock.json
+wp-content/themes/power-of-families/composer.lock


### PR DESCRIPTION
`prettier --check .` currently flags **40 files**. 13 of those are third-party copies or minified builds we deliberately don't reformat, so they're noise. Excluding them brings the count to **27**, all of which are genuinely our own unformatted source.

## What's ignored

| Entry | Why |
| --- | --- |
| `wp-content/themes/power-of-families/bootstrap` | Vendored upstream copy (7 files) — keep byte-identical so it stays diffable against its source release |
| `wp-content/plugins/pof-bloom-plugin/assets/js/jQuery.dotdotdot-master` | Same, vendored upstream copy (6 files) |
| `*.min.js`, `*.min.css` | Minified builds |
| `package-lock.json`, `.../composer.lock` | Generated lockfiles (already passing; included as a forward-looking guard) |

## Notes

Prettier 3 reads **both** `.gitignore` and `.prettierignore` by default (`--ignore-path` defaults to `[.gitignore, .prettierignore]`). Build output and untracked dirs — `wordpress/`, `coverage/`, `test-reports/`, `db-data/` — are therefore already excluded and needed no entries here. That's called out in a comment in the file so it doesn't get duplicated later.

## Scope

**No files were reformatted.** This only changes what Prettier looks at. Verified before/after: 40 → 27, and every one of the 13 newly-excluded files is vendored or minified — nothing of ours got swept up.

Separately worth doing, but deliberately **not** in this PR: running `--write` on the remaining 27 and wiring a `format:check` step into CI. There's currently no Prettier step in `.github/workflows/` and no `lint`/`format` npm script, which is how 40+ files drifted unnoticed. That change touches a lot of theme CSS and deserves its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)