### PR TITLE
Document a pre-merge check for GitHub Copilot review comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,24 @@ of which DB pattern you pick.
 - Linting: `prettier.config.js` and `.phpcs.xml.dist`. Use spaces, not tabs.
 - Deploy: push to `main` triggers rsync of the theme directory to production via `.github/workflows/deploy.yml`.
 
+## Before merging
+
+Make sure every GitHub Copilot review comment on the PR has either been
+addressed or been found unnecessary. Never merge with Copilot feedback left
+unexamined — decide on each comment, and say which ones you're dismissing and
+why.
+
+```sh
+gh pr view <n> --json reviews --jq '.reviews[] | "\(.author.login) [\(.state)]: \(.body)"'
+gh api repos/jloosli/power-of-families/pulls/<n>/comments \
+    --jq '.[] | "\(.user.login) @ \(.path):\(.line)\n\(.body)"'
+```
+
+Substantive feedback lands as inline comments (the second command); the first
+only shows the review summary. Copilot skips generated files, so a
+lockfile-only PR gets "Copilot wasn't able to review any files in this pull
+request" — nothing to action there.
+
 ## Agent skills
 
 ### Issue tracker

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,14 +72,16 @@ why.
 
 ```sh
 gh pr view <n> --json reviews --jq '.reviews[] | "\(.author.login) [\(.state)]: \(.body)"'
-gh api repos/jloosli/power-of-families/pulls/<n>/comments \
+gh api --paginate repos/jloosli/power-of-families/pulls/<n>/comments \
     --jq '.[] | "\(.user.login) @ \(.path):\(.line)\n\(.body)"'
 ```
 
 Substantive feedback lands as inline comments (the second command); the first
-only shows the review summary. Copilot skips generated files, so a
-lockfile-only PR gets "Copilot wasn't able to review any files in this pull
-request" — nothing to action there.
+only shows the review summary. Keep `--paginate` — without it `gh api` returns
+only the first 30 comments, so a busy PR would silently truncate and you'd
+think you'd seen everything. Copilot skips generated files, so a lockfile-only
+PR gets "Copilot wasn't able to review any files in this pull request" —
+nothing to action there.
 
 ## Agent skills
 


### PR DESCRIPTION
Adds a **Before merging** section to `AGENTS.md`: every GitHub Copilot review comment on a PR must be either addressed or explicitly judged unnecessary before merge, and the dismissals should be stated rather than left implicit.

Includes the two `gh` commands to fetch them, plus two details learned the hard way on #61:

- **Substantive feedback arrives as inline comments**, not in the review summary — so `gh pr view --json reviews` alone isn't enough; you need the `pulls/<n>/comments` API.
- **Copilot skips generated files.** A lockfile-only PR gets "Copilot wasn't able to review any files in this pull request," which is a no-op notice rather than unresolved feedback.

Docs only — no behavior change. `npm run format:check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)