### PR TITLE
Document how to request a Copilot re-review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,10 +90,20 @@ you push fixes. If you want it to look again, ask explicitly:
 gh pr edit <n> --add-reviewer "@copilot"
 ```
 
-Do this while the PR is still open. GitHub accepts the request on a merged PR
-and silently discards it — exit 0, no reviewer added, no new review — so the
-window closes at merge. "No new comments" after a push therefore means nobody
-looked again, not that the fix was approved.
+The new review takes a minute or two to arrive, so don't conclude nothing
+happened from an immediate poll. Two traps when checking whether the request
+registered:
+
+- REST `requested_reviewers` lists only Users, never Bots, so a pending
+  Copilot request reads as an empty array there. Check GraphQL
+  `reviewRequests` instead — the bot's login is
+  `copilot-pull-request-reviewer` — or simply wait for the review to post.
+- The request works on a **merged** PR too, so a review can land after you've
+  merged. Ask before merging anyway: a finding that arrives afterwards needs a
+  whole new PR to act on.
+
+So "no new comments" after a push means nobody looked again, not that the fix
+was approved.
 
 ## Agent skills
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,18 @@ think you'd seen everything. Copilot skips generated files, so a lockfile-only
 PR gets "Copilot wasn't able to review any files in this pull request" —
 nothing to action there.
 
+Copilot reviews the commit it was triggered on and does **not** re-review when
+you push fixes. If you want it to look again, ask explicitly:
+
+```sh
+gh pr edit <n> --add-reviewer "@copilot"
+```
+
+Do this while the PR is still open. GitHub accepts the request on a merged PR
+and silently discards it — exit 0, no reviewer added, no new review — so the
+window closes at merge. "No new comments" after a push therefore means nobody
+looked again, not that the fix was approved.
+
 ## Agent skills
 
 ### Issue tracker

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,10 @@ you push fixes. If you want it to look again, ask explicitly:
 gh pr edit <n> --add-reviewer "@copilot"
 ```
 
+The `@copilot` reviewer alias needs a reasonably recent `gh` (verified on
+2.97.0); if your version rejects it, upgrade rather than assuming Copilot
+review is unavailable.
+
 The new review takes a minute or two to arrive, so don't conclude nothing
 happened from an immediate poll. Two traps when checking whether the request
 registered:


### PR DESCRIPTION
Follow-up to #62. That PR added the rule that Copilot comments must be addressed or dismissed before merge; this one records **how to get a second look**, which turned out to be the missing half.

## What it adds

```sh
gh pr edit <n> --add-reviewer "@copilot"
```

Plus the behaviours that make it usable:

- **Copilot reviews only the commit it was triggered on** and does not re-review when you push fixes.
- **The review takes a minute or two to post** — an immediate poll looks like nothing happened.
- **REST `requested_reviewers` lists only Users, never Bots**, so a registered Copilot request reads as an empty array there. GraphQL `reviewRequests` shows it as a Bot (`copilot-pull-request-reviewer`).
- **The request works on a merged PR too**, so a review can land post-merge. Ask before merging anyway — a finding that arrives afterwards needs a whole new PR to act on.
- **The `@copilot` alias needs a recent `gh`** (verified on 2.97.0); an older CLI rejecting it looks like Copilot review being unavailable.

Net effect: "no new comments" after a push means nobody looked again, not that the fix was approved.

## Corrections made during review

This PR's first draft claimed a re-review request on a merged PR is **silently discarded**. That was wrong, and `b088dc9` fixes it. Two mistakes compounded: I checked REST `requested_reviewers` (which never lists Bots) and polled once, immediately, before the review had time to post. In reality the request on #62 worked — Copilot posted a fresh review at 16:38:31, after that PR merged at 16:33:09, reporting "reviewed 1 out of 1 changed files and generated no new comments." So nothing was missed on #62's merits, but the conclusion I drew from it was wrong.

Copilot's own re-reviews on this PR then caught two further issues, both fixed:

- the missing `gh` version note (`f832eed`)
- this description still contradicting the corrected file, now rewritten

Both arrived as **suppressed** comments, which don't appear in the `pulls/<n>/comments` API — worth knowing, since the rule in #62 points at that endpoint. They're only visible in the review body.

Docs only — no behavior change. `npm run format:check` passes; `Format Check` and `Unit Tests` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
