### PR TITLE
Warn that Copilot suppressed comments bypass the inline comments API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,12 +76,22 @@ gh api --paginate repos/jloosli/power-of-families/pulls/<n>/comments \
     --jq '.[] | "\(.user.login) @ \(.path):\(.line)\n\(.body)"'
 ```
 
-Substantive feedback lands as inline comments (the second command); the first
-only shows the review summary. Keep `--paginate` — without it `gh api` returns
-only the first 30 comments, so a busy PR would silently truncate and you'd
-think you'd seen everything. Copilot skips generated files, so a lockfile-only
-PR gets "Copilot wasn't able to review any files in this pull request" —
-nothing to action there.
+Feedback arrives in two places and you have to read both:
+
+- **Inline comments** (the second command) — the line-anchored findings. Keep
+  `--paginate`; without it `gh api` returns only the first 30, so a busy PR
+  would silently truncate and you'd think you'd seen everything.
+- **The review body** (the first command) — besides the summary, this carries
+  _suppressed comments_: lower-confidence findings Copilot withholds from the
+  inline API. They sit in a `<summary>Suppressed comments (N)</summary>` block
+  and never appear in `pulls/<n>/comments`, so an empty result from that
+  endpoint does **not** mean there was no feedback. They can be perfectly
+  valid — both real issues Copilot caught on #63 arrived this way, and
+  following the inline API alone would have merged them unexamined. Print the
+  body in full rather than truncating it.
+
+Copilot skips generated files, so a lockfile-only PR gets "Copilot wasn't able
+to review any files in this pull request" — nothing to action there.
 
 Copilot reviews the commit it was triggered on and does **not** re-review when
 you push fixes. If you want it to look again, ask explicitly:


### PR DESCRIPTION
Closes a gap in the rule added by #62 and refined by #63.

## The problem

#62 tells agents to fetch Copilot feedback from `pulls/<n>/comments`. But Copilot withholds lower-confidence findings as **suppressed comments**, which appear only inside the review body — in a `<summary>Suppressed comments (N)</summary>` block — and **never** at that endpoint.

So an agent following #62 literally would see a zero-length comments array, read "Copilot reviewed 1 out of 1 changed files and generated no new comments" in the summary, and conclude there was nothing to address.

## Why this isn't hypothetical

Both real issues Copilot raised on #63 arrived as suppressed comments:

1. The missing `gh` version note for the `@copilot` alias.
2. The PR description contradicting the corrected file.

Neither appeared in `pulls/<n>/comments` (that endpoint returned `0` throughout). Following the documented procedure alone would have merged both defects unexamined — including one where the PR text asserted the opposite of the file it was changing.

## The change

Restructures the paragraph into the two places feedback actually lands — inline comments and the review body — and states plainly that an empty comments array does not mean there was no feedback, plus to print the body in full rather than truncating it.

Docs only — no behavior change. `npm run format:check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
