### PR TITLE
Report a real exit code when the CI test run fails

### DIFF
--- a/bin/run-tests-ci.sh
+++ b/bin/run-tests-ci.sh
@@ -266,16 +266,24 @@ execute_ci_tests() {
 
     local start_time=$(date +%s)
     
-    # Execute tests and capture output
+    # Execute tests and capture output.
+    #
+    # `cmd | tee` reports tee's exit status, not the runner's, and `set -e` is
+    # suspended inside an `if` condition — so the failure branch below was
+    # unreachable and a genuinely failing suite still exited 0. Read the
+    # runner's own status from PIPESTATUS, immediately after the pipeline and
+    # before any other command can overwrite it.
     local result=0
-    if $phpunit_cmd 2>&1 | tee "$TEST_REPORTS_DIR/test-output.log"; then
+    $phpunit_cmd 2>&1 | tee "$TEST_REPORTS_DIR/test-output.log"
+    local runner_status="${PIPESTATUS[0]}"
+    if [ "$runner_status" -eq 0 ]; then
         local end_time=$(date +%s)
         local duration=$((end_time - start_time))
         log_success "Tests executed successfully in ${duration}s"
     else
         local end_time=$(date +%s)
         local duration=$((end_time - start_time))
-        log_error "Tests failed after ${duration}s"
+        log_error "Tests failed after ${duration}s (runner exited $runner_status)"
         result=1
     fi
 


### PR DESCRIPTION
Refs #74 — fixes the second defect noted at the bottom of that issue. Small and self-contained: one function in one script.

## The bug

`bin/run-tests-ci.sh` piped the test runner into `tee` and branched on the result:

```sh
if $phpunit_cmd 2>&1 | tee "$TEST_REPORTS_DIR/test-output.log"; then
```

A pipeline reports its **last** command's status, so the `if` read *tee's* exit code — always 0. `set -e` is suspended inside an `if` condition, so nothing else caught it either, and the failure branch that sets `result=1` was unreachable. `npm run test:php-ci` exited 0 no matter what.

## Demonstrated, not assumed

I added one deliberately failing assertion and ran the same suite twice — once against `main`'s script, once against this branch.

**Before** (`main`), PHPUnit was unambiguous:

```
FAILURES!
Tests: 81, Assertions: 226, Failures: 1, Skipped: 1.
```

and the script answered:

```
✅ Tests executed successfully in 7s
✅ CI/CD test execution completed successfully!
```

**exit 0.**

**After** (this branch), same failing test:

```
❌ Tests failed after 7s (runner exited 1)
```

**exit 1.** A passing suite still exits 0, verified separately. The temporary assertion was reverted; the diff is one function.

## Blast radius

| caller | affected? |
|---|---|
| PR checks (`simple-tests.yml`) | **No** — invokes `docker compose run --rm test ci-test.sh` directly, bypassing this script |
| Nightly `Comprehensive Testing` | **Yes** — four jobs call `bin/run-tests-ci.sh`; a failing suite reported green |
| `npm run test:php-ci` locally | **Yes** |

So PR CI has been honest all along, which is why this went unnoticed. The nightly has not been — it has reported success daily regardless of test outcomes.

## Implementation

The status is read from `PIPESTATUS` immediately after the pipeline, before any other command can overwrite it. `main()` already ends in `exit $exit_code`, so no further plumbing was required. The error line now includes the runner's actual status to make a non-1 failure (e.g. a container that never started) distinguishable from a test failure.

The identical pattern was fixed in `bin/run-tests-with-reporting.sh` by #71; this is its sibling. #74's primary defect — that `run-tests-with-reporting.sh` never runs tests at all — is untouched here and remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)