### PR TITLE
Close the program list wrapper once instead of twice

### DIFF
--- a/wp-content/themes/power-of-families/inc/PowerOfFamilies/Programs/MyPrograms.php
+++ b/wp-content/themes/power-of-families/inc/PowerOfFamilies/Programs/MyPrograms.php
@@ -60,7 +60,6 @@ class MyPrograms implements HookRegistrar
                 foreach ($progs as $prog) {
                     $output .= $this->render_program($prog);
                 }
-                $output .= "</div>";
             } else {
                 $output .= "<div class='message'>$nosubscriptions</div>";
             }

--- a/wp-content/themes/power-of-families/tests/test-MyPrograms.php
+++ b/wp-content/themes/power-of-families/tests/test-MyPrograms.php
@@ -181,6 +181,53 @@ class test_MyPrograms extends WP_UnitTestCase {
     }
 
     // -------------------------------------------------------------------------
+    // Wrapper markup
+    //
+    // Issue #73: the enrolled-programs branch closed #pof_userprograms twice, so
+    // the stray </div> landed on whatever Genesis wrapper contained the widget
+    // and closed it a level early. Every branch has to hand back balanced
+    // markup, not just the two that always did.
+    // -------------------------------------------------------------------------
+
+    private function assertBalancedDivs( string $output ): void {
+        $this->assertSame(
+            substr_count( $output, '<div' ),
+            substr_count( $output, '</div>' ),
+            "unbalanced <div> markup: $output"
+        );
+    }
+
+    public function test_logged_out_markup_is_balanced() {
+        wp_set_current_user( 0 );
+
+        $this->assertBalancedDivs( $this->my_programs->show_programs( array() ) );
+    }
+
+    public function test_no_programs_markup_is_balanced() {
+        $this->enroll( array() );
+
+        $this->assertBalancedDivs( $this->my_programs->show_programs( array() ) );
+    }
+
+    public function test_one_program_markup_is_balanced() {
+        $this->enroll( array( $this->program( 'Goalsetting', 'home: https://example.com/one' ) ) );
+
+        $this->assertBalancedDivs( $this->my_programs->show_programs( array() ) );
+    }
+
+    public function test_several_programs_markup_is_balanced() {
+        $this->enroll(
+            array(
+                $this->program( 'Goalsetting', 'home: https://example.com/one' ),
+                $this->program( 'Assessments', 'image: https://example.com/i.png' ),
+                $this->program( 'Journaling', null ),
+            )
+        );
+
+        $this->assertBalancedDivs( $this->my_programs->show_programs( array() ) );
+    }
+
+    // -------------------------------------------------------------------------
     // Shortcode attributes
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #73.

## The change

`MyPrograms::show_programs()` closed `#pof_userprograms` twice when the user
had at least one program. One line deleted; the other three branches were
already balanced.

## What the stray tag was doing

`.program` is floated, so the tiles escape `#pof_userprograms` and the
extra `</div>` landed on `.entry-content` instead. Measured on
`/my-programs/` (the only page carrying the shortcode) as a member with
four real program groups:

|                                    | before | after |
| ---------------------------------- | ------ | ----- |
| `<div` / `</div>` in the whole page | 15 / 16 | 15 / 15 |
| children of `.entry-content`        | 1      | 7     |
| "Member Package" inside `.entry-content` | no | yes  |

Everything below the shortcode used to be a sibling of `.entry-content`
rather than a child of it.

## Rendered before/after

Captured the member view of `/my-programs/` with and without the fix and
replayed both documents against the live stylesheets (only the top-level
document stubbed, so real CSS and assets):

- identical, pixel for pixel, from the top of the page down to y=777 —
  the program list itself is untouched;
- below that, the two renders match **exactly** once the fixed one is
  shifted down 15px (`compare -metric AE` → 0 differing pixels).

So the whole visible effect is that everything under the program list
moves up 15px: `.entry-content`'s clearfix used to sit immediately after
the floated tiles and now sits at the end of the page. No reflow, no
width change, no text wrapping around the tiles' floats — the layout
production CSS is sitting on does not change shape.

## Tests

Added four balance assertions covering every branch
(`tests/test-MyPrograms.php`). Two of them fail against the old markup:

```
unbalanced <div> markup: <div id='pof_userprograms'><h2>My Programs</h2>…
Tests: 4, Assertions: 4, Failures: 2.
```

Full suite green: `OK (116 tests, 289 assertions)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)