### PR TITLE
Point AGENTS.md at the tracker; record candidate status in the review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,31 @@ was approved.
 
 GitHub Issues on `jloosli/power-of-families`, via the `gh` CLI. See `docs/agents/issue-tracker.md`.
 
+**The tracker is the backlog — nothing else is.** In particular
+[docs/architecture/2026-08-12-deepening-review.md](docs/architecture/2026-08-12-deepening-review.md)
+is a dated analysis snapshot, deliberately frozen, and is **not** a work queue. It decays:
+its candidate 05 had every figure move within two days, and grew rather than shrank. Where
+it and an issue disagree, the issue is right. Start with `gh issue list`.
+
+Status of that review's nine candidates, so nobody re-derives it from `git log`:
+
+| Candidate                              | Outcome                                    |
+| -------------------------------------- | ------------------------------------------ |
+| 01 collapse the duplicated Settings Screen | done — #69, by retiring the plugin     |
+| 02 type the field-definition array     | done — #70                                 |
+| 03 delete `tests/reporting/`           | done — #66                                 |
+| 04 seeding harness off the bootstrap   | **open — #79**                             |
+| 05 shared `bin/lib/common.sh`          | **open — #78**                             |
+| 06 split `run-tests.sh`'s two roles    | done — #67                                 |
+| 07 extract the program-description parser | done — #72, closing #41                 |
+| 08 declare the program contract        | **open — #80** (`needs-triage`)            |
+| 09 break up `POM_Bloom_Program`        | void — the plugin was retired by 01        |
+
+Work found by *running* the tooling rather than reading it was never part of that review and
+lives only in the tracker — currently #74 and #76. Both matter when reading a green build:
+`bin/run-tests-with-reporting.sh` runs no tests at all, and two of the nightly's four test
+jobs select zero tests and pass.
+
 ### Triage labels
 
 Default canonical vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,8 +57,12 @@ schema regardless of which DB pattern you pick.
 - CSS is plain PostCSS (postcss-nested, autoprefixer). Config: `postcss.config.js`.
 - Linting: `prettier.config.js` and `.phpcs.xml.dist`. Use spaces, not tabs.
 - Deploy: push to `main` triggers rsync of the theme directory to production via `.github/workflows/deploy.yml`.
-- Coverage reporting needs `xmlstarlet` on the **host** (`brew install xmlstarlet`); it is not in the containers. `bin/run-tests-ci.sh` and `bin/ci-coverage-integration.sh` abort without it rather than reporting a false 0%.
-- `npm run test:php-ci` now exits non-zero when PHPUnit fails (#75 — it used to read `tee`'s status and always exit 0). Its `Total Tests` / `Assertions` still print 0 on a fully clean run, though: the parser only matches PHPUnit's `Tests: N` form, which a clean run doesn't emit (#76). `test-reports/test-output.log` remains the source of truth for `OK (N tests, M assertions)`.
+- Coverage reporting needs `xmlstarlet` on the **host** (`brew install xmlstarlet`); it is
+  not in the containers. `bin/run-tests-ci.sh` and `bin/ci-coverage-integration.sh` abort
+  without it rather than reporting a false 0%.
+- `npm run test:php-ci` exits non-zero on failure since #75. Its `Total Tests` /
+  `Assertions` still print 0 on a fully clean run (#76), so `test-reports/test-output.log`
+  remains the source of truth for `OK (N tests, M assertions)`.
 
 ## Before merging
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ schema regardless of which DB pattern you pick.
 - Linting: `prettier.config.js` and `.phpcs.xml.dist`. Use spaces, not tabs.
 - Deploy: push to `main` triggers rsync of the theme directory to production via `.github/workflows/deploy.yml`.
 - Coverage reporting needs `xmlstarlet` on the **host** (`brew install xmlstarlet`); it is not in the containers. `bin/run-tests-ci.sh` and `bin/ci-coverage-integration.sh` abort without it rather than reporting a false 0%.
-- `npm run test:php-ci` exits 0 even when PHPUnit fails. Read `test-reports/test-output.log` for the real `OK (N tests, M assertions)` line rather than trusting the summary.
+- `npm run test:php-ci` now exits non-zero when PHPUnit fails (#75 — it used to read `tee`'s status and always exit 0). Its `Total Tests` / `Assertions` still print 0 on a fully clean run, though: the parser only matches PHPUnit's `Tests: N` form, which a clean run doesn't emit (#76). `test-reports/test-output.log` remains the source of truth for `OK (N tests, M assertions)`.
 
 ## Before merging
 
@@ -130,19 +130,19 @@ it and an issue disagree, the issue is right. Start with `gh issue list`.
 
 Status of that review's nine candidates, so nobody re-derives it from `git log`:
 
-| Candidate                              | Outcome                                    |
-| -------------------------------------- | ------------------------------------------ |
-| 01 collapse the duplicated Settings Screen | done — #69, by retiring the plugin     |
-| 02 type the field-definition array     | done — #70                                 |
-| 03 delete `tests/reporting/`           | done — #66                                 |
-| 04 seeding harness off the bootstrap   | **open — #79**                             |
-| 05 shared `bin/lib/common.sh`          | **open — #78**                             |
-| 06 split `run-tests.sh`'s two roles    | done — #67                                 |
-| 07 extract the program-description parser | done — #72, closing #41                 |
-| 08 declare the program contract        | **open — #80** (`needs-triage`)            |
-| 09 break up `POM_Bloom_Program`        | void — the plugin was retired by 01        |
+| Candidate                                  | Outcome                             |
+| ------------------------------------------ | ----------------------------------- |
+| 01 collapse the duplicated Settings Screen | done — #69, by retiring the plugin  |
+| 02 type the field-definition array         | done — #70                          |
+| 03 delete `tests/reporting/`               | done — #66                          |
+| 04 seeding harness off the bootstrap       | **open — #79**                      |
+| 05 shared `bin/lib/common.sh`              | **open — #78**                      |
+| 06 split `run-tests.sh`'s two roles        | done — #67                          |
+| 07 extract the program-description parser  | done — #72, closing #41             |
+| 08 declare the program contract            | **open — #80** (`needs-triage`)     |
+| 09 break up `POM_Bloom_Program`            | void — the plugin was retired by 01 |
 
-Work found by *running* the tooling rather than reading it was never part of that review and
+Work found by _running_ the tooling rather than reading it was never part of that review and
 lives only in the tracker — currently #74 and #76. Both matter when reading a green build:
 `bin/run-tests-with-reporting.sh` runs no tests at all, and two of the nightly's four test
 jobs select zero tests and pass.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,30 +122,10 @@ was approved.
 
 GitHub Issues on `jloosli/power-of-families`, via the `gh` CLI. See `docs/agents/issue-tracker.md`.
 
-**The tracker is the backlog — nothing else is.** In particular
-[docs/architecture/2026-08-12-deepening-review.md](docs/architecture/2026-08-12-deepening-review.md)
-is a dated analysis snapshot, deliberately frozen, and is **not** a work queue. It decays:
-its candidate 05 had every figure move within two days, and grew rather than shrank. Where
-it and an issue disagree, the issue is right. Start with `gh issue list`.
-
-Status of that review's nine candidates, so nobody re-derives it from `git log`:
-
-| Candidate                                  | Outcome                             |
-| ------------------------------------------ | ----------------------------------- |
-| 01 collapse the duplicated Settings Screen | done — #69, by retiring the plugin  |
-| 02 type the field-definition array         | done — #70                          |
-| 03 delete `tests/reporting/`               | done — #66                          |
-| 04 seeding harness off the bootstrap       | **open — #79**                      |
-| 05 shared `bin/lib/common.sh`              | **open — #78**                      |
-| 06 split `run-tests.sh`'s two roles        | done — #67                          |
-| 07 extract the program-description parser  | done — #72, closing #41             |
-| 08 declare the program contract            | **open — #80** (`needs-triage`)     |
-| 09 break up `POM_Bloom_Program`            | void — the plugin was retired by 01 |
-
-Work found by _running_ the tooling rather than reading it was never part of that review and
-lives only in the tracker — currently #74 and #76. Both matter when reading a green build:
-`bin/run-tests-with-reporting.sh` runs no tests at all, and two of the nightly's four test
-jobs select zero tests and pass.
+**The tracker is the backlog — nothing else is.** Start with `gh issue list`. Documents under
+`docs/architecture/` are dated analysis snapshots, not work queues; where one disagrees with
+an issue, the issue is right. The 2026-08-12 deepening review carries a table mapping its
+candidates to their issues, kept there because it goes stale as they close.
 
 ### Triage labels
 

--- a/docs/architecture/2026-08-12-deepening-review.md
+++ b/docs/architecture/2026-08-12-deepening-review.md
@@ -386,13 +386,26 @@ hypothetical. Then 03 is a free deletion clearing 1,514 dead lines out of the bo
 > the ordering argument above only held while an extraction was the plan. What remains is
 > **02 → 07 → 04/05 → 08**.
 >
-> **This document is no longer the backlog (2026-08-13).** 02 (#70) and 07 (#72) have since
-> landed, so every candidate is either done, void, or filed: **04 → #79, 05 → #78,
-> 08 → #80**. Those issues carry the live state and re-verify each premise against `main`;
-> this file stays a dated snapshot of the original analysis. Where the two disagree, the
-> issue is right — candidate 05 in particular has grown since this was written. Work found
-> by running the pipeline rather than reading it is tracked only in the issue tracker
-> (#73, #74, #76), and was never part of this review.
+> **This document is no longer the backlog (2026-08-13).** Every candidate is now done,
+> void, or filed. Those issues carry the live state and re-verify each premise against
+> `main`; this file stays a dated snapshot of the original analysis. Where the two disagree,
+> the issue is right — candidate 05 in particular has grown since this was written.
+>
+> | Candidate                                  | Outcome                            |
+> | ------------------------------------------ | ---------------------------------- |
+> | 01 collapse the duplicated Settings Screen | done — #69, by retiring the plugin |
+> | 02 type the field-definition array         | done — #70                         |
+> | 03 delete `tests/reporting/`               | done — #66                         |
+> | 04 seeding harness off the bootstrap       | **open — #79**                     |
+> | 05 shared `bin/lib/common.sh`              | **open — #78**                     |
+> | 06 split `run-tests.sh`'s two roles        | done — #67                         |
+> | 07 extract the program-description parser  | done — #72, closing #41            |
+> | 08 declare the program contract            | **open — #80** (`needs-triage`)    |
+> | 09 break up `POM_Bloom_Program`            | void — plugin retired by 01        |
+>
+> This table is temporary: once 04, 05 and 08 close, `gh issue list` is the only thing worth
+> reading. Work found by _running_ the tooling rather than reading it — #73, #74, #76 — was
+> never part of this review and lives only in the tracker.
 
 > **Updated 2026-08-13.** 02 and 07 have landed too. What remains is **04/05 → 08**, and
 > 04/05 should follow issue #68's reporting work — both touch `bin/` and the PHPUnit


### PR DESCRIPTION
Docs only. Two files, no code changes.

#81 pointed the deepening review at its tracking issues. This points the other way — from the file agents read first, to the tracker — and records which candidates have landed.

## `AGENTS.md` — the durable half

A short rule under `### Issue tracker`: the tracker is the backlog, documents under `docs/architecture/` are dated analysis snapshots rather than work queues, and where one disagrees with an issue, the issue is right.

Also corrects a Key Fact that had gone stale. It claimed `npm run test:php-ci` "exits 0 even when PHPUnit fails" — true when written, fixed since by #75. It now records what is *actually* still wrong: the counts print 0 on a fully clean run, because the parser only matches PHPUnit's `Tests: N` form and a clean run emits `OK (N tests, M assertions)` instead (#76).

## The review — the temporary half

The nine-row candidate status table lives here rather than in `AGENTS.md`, because it goes stale the moment 04, 05 and 08 close. It sits with the per-candidate annotations #81 added, and says on its face that it is temporary and `gh issue list` outlives it.

It exists so that *which candidates are done* stops being reconstructible only from `git log`: 01, 02, 03, 06 and 07 landed, 09 is void, and 04 → #79, 05 → #78, 08 → #80 are open.

## Note on the Format Check failure earlier in this PR

Worth recording, because it invalidated a check I had been relying on all session. Prettier 3 defaults `--ignore-path` to **both** `.gitignore` and `.prettierignore`, and `.gitignore` lists `.claude/`. Every `prettier --check` I ran against a path inside `.claude/worktrees/` therefore matched zero files and reported "All matched files use Prettier code style!" without reading anything — a vacuous pass. Formatting from inside a worktree needs `--ignore-path /dev/null`, which is how both files here were verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)