### PR TITLE
Declare the program contract instead of reflecting on it

### DIFF
--- a/docs/architecture/2026-08-12-deepening-review.md
+++ b/docs/architecture/2026-08-12-deepening-review.md
@@ -336,6 +336,15 @@ string), `pof_save_meta`/`pof_meta_nonce` (twice in one file), `POF_Affiliate_Li
 > `:162-163`, and `AffiliateLinker`'s static singleton at `:9`/`:26`. This is the only
 > remaining candidate touching production theme code, and the `has-settings => true` fatal
 > is latent rather than live, so it wants a human decision on scope before an agent starts.
+>
+> **Split and the interface half done (2026-08-13).** The contract landed as `ProgramModule`
+> in #85 — named that, not `Program`, because `EnrolledProgram` in the same namespace means
+> a program a customer bought. The "related, smaller" paragraph above became #86, minus
+> `pof_save_meta`/`pof_meta_nonce`, which no longer exist: they went with the Bloom
+> retirement (#69). Two things this candidate did not predict, both from checking production
+> rather than call sites: the live snapshot has only `My_Programs` active, so the changed
+> path was unreachable there — and the affiliate-linker ajax button has never worked, since
+> it demands a nonce no caller sends (#87).
 
 ---
 
@@ -391,19 +400,19 @@ hypothetical. Then 03 is a free deletion clearing 1,514 dead lines out of the bo
 > `main`; this file stays a dated snapshot of the original analysis. Where the two disagree,
 > the issue is right — candidate 05 in particular has grown since this was written.
 >
-> | Candidate                                  | Outcome                            |
-> | ------------------------------------------ | ---------------------------------- |
-> | 01 collapse the duplicated Settings Screen | done — #69, by retiring the plugin |
-> | 02 type the field-definition array         | done — #70                         |
-> | 03 delete `tests/reporting/`               | done — #66                         |
-> | 04 seeding harness off the bootstrap       | **open — #79**                     |
-> | 05 shared `bin/lib/common.sh`              | **open — #78**                     |
-> | 06 split `run-tests.sh`'s two roles        | done — #67                         |
-> | 07 extract the program-description parser  | done — #72, closing #41            |
-> | 08 declare the program contract            | **open — #80** (`needs-triage`)    |
-> | 09 break up `POM_Bloom_Program`            | void — plugin retired by 01        |
+> | Candidate                                  | Outcome                                   |
+> | ------------------------------------------ | ----------------------------------------- |
+> | 01 collapse the duplicated Settings Screen | done — #69, by retiring the plugin        |
+> | 02 type the field-definition array         | done — #70                                |
+> | 03 delete `tests/reporting/`               | done — #66                                |
+> | 04 seeding harness off the bootstrap       | **open — #79**                            |
+> | 05 shared `bin/lib/common.sh`              | **open — #78**                            |
+> | 06 split `run-tests.sh`'s two roles        | done — #67                                |
+> | 07 extract the program-description parser  | done — #72, closing #41                   |
+> | 08 declare the program contract            | interface done — #85; keys **open — #86** |
+> | 09 break up `POM_Bloom_Program`            | void — plugin retired by 01               |
 >
-> This table is temporary: once 04, 05 and 08 close, `gh issue list` is the only thing worth
+> This table is temporary: once 04, 05 and 86 close, `gh issue list` is the only thing worth
 > reading. Work found by _running_ the tooling rather than reading it — #73, #74, #76 — was
 > never part of this review and lives only in the tracker.
 

--- a/wp-content/themes/power-of-families/inc/PowerOfFamilies/Programs/AffiliateLinker.php
+++ b/wp-content/themes/power-of-families/inc/PowerOfFamilies/Programs/AffiliateLinker.php
@@ -2,13 +2,21 @@
 
 namespace PowerOfFamilies\Programs;
 
-use PowerOfFamilies\HookRegistrar;
-
-class AffiliateLinker implements HookRegistrar
+class AffiliateLinker implements ProgramModule
 {
-    public static ?AffiliateLinkerSettings $settingsInstance = null;
+    private ?AffiliateLinkerSettings $settings = null;
 
     public string $affiliate_id = '';
+
+    /**
+     * The token namespaces script handles and hook names. This module
+     * registers neither under a namespaced name -- its ajax action and cron
+     * hook are fixed strings -- so it takes the argument and drops it, for
+     * the sake of a uniform construction contract.
+     */
+    public function __construct(string $token = '')
+    {
+    }
 
     public function register(): void
     {
@@ -23,14 +31,14 @@ class AffiliateLinker implements HookRegistrar
         add_action('POF_Affiliate_Linker_CRON', [$this, 'add_amazon']);
     }
 
-    public static function getSettingsInstance() : AffiliateLinkerSettings
+    /**
+     * Built once per instance rather than once per request: the settings
+     * screen was a static singleton, which is process-wide state that two
+     * tests -- or two Settings instances -- would have had to share.
+     */
+    public function settings() : ?ProgramSettings
     {
-        if (is_null(self::$settingsInstance)) {
-            self::$settingsInstance = new AffiliateLinkerSettings();
-        }
-
-        return self::$settingsInstance;
-
+        return $this->settings ??= new AffiliateLinkerSettings();
     }
 
     public function activation() : void

--- a/wp-content/themes/power-of-families/inc/PowerOfFamilies/Programs/AffiliateLinkerSettings.php
+++ b/wp-content/themes/power-of-families/inc/PowerOfFamilies/Programs/AffiliateLinkerSettings.php
@@ -4,7 +4,7 @@ namespace PowerOfFamilies\Programs;
 
 use PowerOfFamilies\HookRegistrar;
 
-class AffiliateLinkerSettings implements HookRegistrar {
+class AffiliateLinkerSettings implements HookRegistrar, ProgramSettings {
 
     public function register(): void {
 //        add_action( 'pof_programs_settings_admin_end', array( $this, 'add_script' ) );
@@ -38,7 +38,7 @@ JS;
      * Build settings fields
      * @return array Fields to be displayed on settings page
      */
-    public function getSettings() {
+    public function getSettings(): array {
 
 
         $settings = array(

--- a/wp-content/themes/power-of-families/inc/PowerOfFamilies/Programs/MyPrograms.php
+++ b/wp-content/themes/power-of-families/inc/PowerOfFamilies/Programs/MyPrograms.php
@@ -2,18 +2,28 @@
 
 namespace PowerOfFamilies\Programs;
 
-use PowerOfFamilies\HookRegistrar;
-
-class MyPrograms implements HookRegistrar
+class MyPrograms implements ProgramModule
 {
-
-    public static mixed $settingsInstance = null;
 
     private ProgramMembership $membership;
 
+    /**
+     * The token is nullable, and $membership is a second argument the
+     * contract does not mention, because both are widenings PHP allows an
+     * implementation to make: tests construct this class directly, with a
+     * fake membership and no token.
+     */
     public function __construct(private ?string $token = null, ?ProgramMembership $membership = null)
     {
         $this->membership = $membership ?? new GroupsMembership();
+    }
+
+    /**
+     * This module is a shortcode; it has nothing to configure.
+     */
+    public function settings() : ?ProgramSettings
+    {
+        return null;
     }
 
     public function register(): void

--- a/wp-content/themes/power-of-families/inc/PowerOfFamilies/Programs/ProgramModule.php
+++ b/wp-content/themes/power-of-families/inc/PowerOfFamilies/Programs/ProgramModule.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace PowerOfFamilies\Programs;
+
+use PowerOfFamilies\HookRegistrar;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * One of the optional feature modules listed under "Active Programs".
+ *
+ * Not to be confused with {@see EnrolledProgram}, which is a program a
+ * customer has bought. These are the admin checkboxes:
+ * {@see \PowerOfFamilies\Settings} instantiates the checked ones, cascades
+ * `register()` to them, and folds their settings screens into its own.
+ *
+ * The contract is declared here because Settings used to infer it. It read
+ * each class's constructor with ReflectionClass to decide whether to pass
+ * the token, then called `getSettingsInstance()` -- a method no type
+ * declared, so a module marked as having settings but missing that method
+ * fataled every admin request. Both halves are stated instead of sniffed:
+ * every module is constructed with the token, and every module answers
+ * `settings()`.
+ */
+interface ProgramModule extends HookRegistrar
+{
+    /**
+     * @param string $token Settings page slug / option prefix root. Modules
+     *                      use it to namespace script handles; one that has
+     *                      no use for it still accepts it, so that
+     *                      construction is uniform across the registry.
+     */
+    public function __construct(string $token);
+
+    /**
+     * This module's settings screen, or null when it contributes none.
+     */
+    public function settings(): ?ProgramSettings;
+}

--- a/wp-content/themes/power-of-families/inc/PowerOfFamilies/Programs/ProgramSettings.php
+++ b/wp-content/themes/power-of-families/inc/PowerOfFamilies/Programs/ProgramSettings.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace PowerOfFamilies\Programs;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * A {@see ProgramModule}'s contribution to the POF Settings screen.
+ *
+ * One implementation is one tab. The array is the legacy section shape --
+ * {@see \PowerOfFamilies\Settings::settings_fields()} keys it by the module
+ * and converts each field to a {@see \PowerOfFamilies\FieldDefinition}, so
+ * fields declared here may stay arrays.
+ */
+interface ProgramSettings
+{
+    /**
+     * @return array{title: string, description?: string, fields?: array}
+     */
+    public function getSettings(): array;
+}

--- a/wp-content/themes/power-of-families/inc/PowerOfFamilies/Settings.php
+++ b/wp-content/themes/power-of-families/inc/PowerOfFamilies/Settings.php
@@ -2,6 +2,8 @@
 
 namespace PowerOfFamilies;
 
+use PowerOfFamilies\Programs\ProgramModule;
+
 if (!defined('ABSPATH')) {
     exit;
 }
@@ -36,8 +38,8 @@ class Settings implements HookRegistrar
     public array $settings = [];
 
     /**
-     * Active programs
-     * @var array
+     * Active programs, keyed by their registry key.
+     * @var array<string, ProgramModule>
      * @access public
      * @since  2.0.0
      */
@@ -59,9 +61,7 @@ class Settings implements HookRegistrar
         add_action('admin_menu', [$this, 'add_menu_item']);
 
         foreach ($this->programs as $program) {
-            if ($program instanceof HookRegistrar) {
-                $program->register();
-            }
+            $program->register();
         }
     }
 
@@ -91,7 +91,13 @@ class Settings implements HookRegistrar
 
     /**
      * Get available programs from the programs directory
-     * @return array
+     *
+     * Every listed class must implement {@see ProgramModule}. There is no
+     * `has-settings` flag any more: a module answers `settings()` for
+     * itself, so the registry cannot claim a settings screen that the class
+     * does not actually provide.
+     *
+     * @return array<string, array{class: string, name: string}>
      */
     private function getAvailablePrograms(): array
     {
@@ -99,8 +105,8 @@ class Settings implements HookRegistrar
         // and must stay stable for backward compatibility; the `class` field
         // is the actual PHP class name in the PowerOfFamilies\Programs namespace.
         return [
-            'Affiliate_Linker' => ['class' => 'AffiliateLinker', 'name' => 'Affiliate Linker', 'has-settings' => true],
-            'My_Programs'      => ['class' => 'MyPrograms',      'name' => 'My Programs',      'has-settings' => false],
+            'Affiliate_Linker' => ['class' => 'AffiliateLinker', 'name' => 'Affiliate Linker'],
+            'My_Programs'      => ['class' => 'MyPrograms',      'name' => 'My Programs'],
         ];
     }
 
@@ -109,6 +115,9 @@ class Settings implements HookRegistrar
         return get_option('pof_active_programs', []);
     }
 
+    /**
+     * @return array<string, ProgramModule>
+     */
     public function loadActivePrograms(): array
     {
         $available = $this->getAvailablePrograms();
@@ -116,14 +125,9 @@ class Settings implements HookRegistrar
         foreach ($this->getActivePrograms() as $program) {
             if (array_key_exists($program, $available)) {
                 $ClassName = '\PowerOfFamilies\Programs\\' . $available[$program]['class'];
-                // Some program classes accept the token (e.g. for script handle
-                // namespacing), others take no constructor args. Inspect the
-                // ctor and pass the token only when it's expected so we don't
-                // emit "Too many arguments" warnings under PHP 8.4+.
-                $ctor = ( new \ReflectionClass( $ClassName ) )->getConstructor();
-                $programs[$program] = ( $ctor && $ctor->getNumberOfParameters() > 0 )
-                    ? new $ClassName( $this->token )
-                    : new $ClassName();
+                // ProgramModule declares the constructor, so every module
+                // takes the token and there is nothing to inspect at runtime.
+                $programs[$program] = new $ClassName($this->token);
             }
         }
         return $programs;
@@ -157,11 +161,13 @@ class Settings implements HookRegistrar
             )
         );
 
-        foreach ($this->getActivePrograms() as $program) {
-            $programs = $this->getAvailablePrograms();
-            if (isset($programs[$program]) && $programs[$program]['has-settings']) {
-                $theProgramSettings = $this->programs[$program]->getSettingsInstance();
-                $settings[$program] = $theProgramSettings->getSettings();
+        // One tab per active module that declares a settings screen. Modules
+        // are already filtered to the available ones and are in the order the
+        // option lists them, so the tabs keep the order they had.
+        foreach ($this->programs as $program => $module) {
+            $programSettings = $module->settings();
+            if (null !== $programSettings) {
+                $settings[$program] = $programSettings->getSettings();
             }
         }
 

--- a/wp-content/themes/power-of-families/phpunit.xml
+++ b/wp-content/themes/power-of-families/phpunit.xml
@@ -63,6 +63,7 @@
             <file>./tests/test-SiteChrome.php</file>
             <file>./tests/test-SharingControls.php</file>
             <file>./tests/test-MyPrograms.php</file>
+            <file>./tests/test-ProgramModule.php</file>
             <file>./tests/test-ProgramDescription.php</file>
             <file>./tests/test-GroupsMembership.php</file>
             <file>./tests/test-AffiliateLinker.php</file>

--- a/wp-content/themes/power-of-families/tests/test-ProgramModule.php
+++ b/wp-content/themes/power-of-families/tests/test-ProgramModule.php
@@ -1,0 +1,142 @@
+<?php
+
+use PowerOfFamilies\Programs\AffiliateLinker;
+use PowerOfFamilies\Programs\AffiliateLinkerSettings;
+use PowerOfFamilies\Programs\MyPrograms;
+use PowerOfFamilies\Programs\ProgramModule;
+use PowerOfFamilies\Programs\ProgramSettings;
+use PowerOfFamilies\Settings;
+
+/**
+ * Tests for the program-module contract.
+ *
+ * Closes issue #80. Settings used to reach for a module's shape at runtime:
+ * ReflectionClass decided whether the constructor wanted the token, and a
+ * `has-settings` flag in the registry decided whether to call
+ * `getSettingsInstance()` -- a method nothing declared, so a registry entry
+ * flagged `true` for a class without it fataled every admin request.
+ * ProgramModule declares both halves, and these tests hold the registry to
+ * them.
+ *
+ * @package Power_Of_Families
+ */
+class test_ProgramModule extends WP_UnitTestCase {
+
+    protected function tearDown(): void {
+        delete_option( 'pof_active_programs' );
+        parent::tearDown();
+    }
+
+    /**
+     * The registry is private, and deliberately read here rather than
+     * duplicated: a module added to it in future is covered by these tests
+     * without anyone remembering to list it twice.
+     *
+     * @return string[]
+     */
+    private function registry_keys(): array {
+        $available = new ReflectionMethod( Settings::class, 'getAvailablePrograms' );
+        $available->setAccessible( true );
+
+        return array_keys( $available->invoke( new Settings( 'pof' ) ) );
+    }
+
+    /**
+     * @param string[] $keys
+     */
+    private function activate( array $keys, string $token = 'pof' ): Settings {
+        update_option( 'pof_active_programs', $keys );
+
+        return new Settings( $token );
+    }
+
+    /**
+     * The guard that replaces the latent fatal: a class listed in the
+     * registry that does not implement the contract cannot be constructed
+     * with the token, and cannot answer settings(). Both are declared now,
+     * so this fails at the registry rather than on an admin request.
+     */
+    public function test_every_registered_program_implements_the_contract() {
+        $keys = $this->registry_keys();
+
+        $settings = $this->activate( $keys );
+
+        $this->assertCount( count( $keys ), $settings->programs );
+        foreach ( $keys as $key ) {
+            $this->assertInstanceOf(
+                ProgramModule::class,
+                $settings->programs[ $key ],
+                sprintf( 'Program "%s" is listed in the registry but does not implement ProgramModule.', $key )
+            );
+        }
+    }
+
+    /**
+     * The reflection sniff existed to avoid passing the token to a module
+     * that took no constructor arguments. Every module takes it now -- and
+     * MyPrograms, which actually uses it, still receives it.
+     */
+    public function test_active_programs_are_constructed_with_the_token() {
+        $settings = $this->activate( array( 'My_Programs' ), 'pof_token' );
+
+        wp_register_script( 'pof_token-frontend', 'https://example.org/frontend.js', array(), '1', true );
+        $settings->programs['My_Programs']->enqueue_scripts();
+
+        $this->assertTrue(
+            wp_script_is( 'pof_token-frontend', 'enqueued' ),
+            'MyPrograms enqueues <token>-frontend, so a missing handle means the token never reached the constructor.'
+        );
+    }
+
+    public function test_module_with_a_settings_screen_declares_it() {
+        $linker = new AffiliateLinker( 'pof' );
+
+        $screen = $linker->settings();
+
+        $this->assertInstanceOf( ProgramSettings::class, $screen );
+        $this->assertInstanceOf( AffiliateLinkerSettings::class, $screen );
+    }
+
+    public function test_settings_screen_is_built_once_per_module() {
+        $linker = new AffiliateLinker( 'pof' );
+
+        $this->assertSame( $linker->settings(), $linker->settings() );
+    }
+
+    /**
+     * The screen used to live in a static property, so every AffiliateLinker
+     * in the process shared one -- state that outlived the object holding it.
+     */
+    public function test_settings_screens_are_not_shared_between_modules() {
+        $this->assertNotSame(
+            ( new AffiliateLinker( 'pof' ) )->settings(),
+            ( new AffiliateLinker( 'pof' ) )->settings()
+        );
+    }
+
+    public function test_module_without_a_settings_screen_says_so() {
+        $this->assertNull( ( new MyPrograms( 'pof' ) )->settings() );
+    }
+
+    /**
+     * The end of the chain: what a module declares is what the settings page
+     * shows. Affiliate_Linker contributes a tab, My_Programs does not.
+     */
+    public function test_only_modules_with_a_screen_contribute_a_tab() {
+        $settings = $this->activate( array( 'Affiliate_Linker', 'My_Programs' ) );
+
+        $settings->init_settings();
+
+        $this->assertArrayHasKey( 'Affiliate_Linker', $settings->settings );
+        $this->assertSame( 'Amazon Affiliate Linker', $settings->settings['Affiliate_Linker']['title'] );
+        $this->assertArrayNotHasKey( 'My_Programs', $settings->settings );
+    }
+
+    public function test_inactive_module_contributes_no_tab() {
+        $settings = $this->activate( array( 'My_Programs' ) );
+
+        $settings->init_settings();
+
+        $this->assertArrayNotHasKey( 'Affiliate_Linker', $settings->settings );
+    }
+}


### PR DESCRIPTION
Closes the interface half of #80 (candidate 08). The shared-constants half is split out to #86, as #80 suggested — it is independent and much lower risk.

## What changed

`Settings` inferred two things about a program module that nothing declared:

1. **Construction.** `ReflectionClass` sniffed constructor arity to decide whether to pass the token.
2. **Settings screens.** A `has-settings` flag in the registry gated a call to `getSettingsInstance()` — a method no type declared. A module registered `has-settings => true` without that method fataled every admin request.

`ProgramModule` declares both: every module takes the token, and every module answers `settings()` with a `ProgramSettings` screen or `null`. The reflection branch and the registry flag both disappear — a module now answers for its own screen, so the registry can no longer claim one the class does not provide.

`AffiliateLinker`'s screen also moves off a `static` property onto the instance. It was process-wide state and nothing needed it to be.

## Naming

The interface is `ProgramModule`, not `Program` as the review sketched. `EnrolledProgram` already lives in the same namespace and means a program a *customer bought*; these are the admin checkboxes under "Active Programs". `Program` next to `EnrolledProgram` would have read as the same concept.

## Risk

#80 flagged this as the only remaining candidate touching production theme code, so it was checked against production rather than only against tests.

**The production snapshot has only `My_Programs` active** — `Affiliate_Linker` is off. Running the real `Settings` through wp-cli against that database, on this branch:

```
active option: ["My_Programs"]
constructed:   {"My_Programs":"PowerOfFamilies\Programs\MyPrograms"}
tabs:          ["standard"]

with Affiliate_Linker active:
constructed:   {"Affiliate_Linker":"...\AffiliateLinker","My_Programs":"...\MyPrograms"}
tabs:          ["standard","Affiliate_Linker"]
linker screen: PowerOfFamilies\Programs\AffiliateLinkerSettings
myprograms:    NULL
```

The live configuration behaves identically: `MyPrograms` was constructed with the token before (reflection saw arity > 0) and still is. The path that actually changed — `getSettingsInstance()` → `settings()` — is only reachable when `Affiliate_Linker` is on, which production does not do.

**One thing I could not read, flagged rather than assumed** (the candidate 07 discipline #80 asked for): `active_plugins` in the snapshot still lists `pof-programs`, and that plugin's source is not in this repo — `deploy.yml` rsyncs only the theme, and `setup:sync-plugins` excludes it. The only removed public API is `AffiliateLinker::getSettingsInstance()`, reachable only as `\PowerOfFamilies\Programs\AffiliateLinker::…`, which the theme's autoloader alone provides; a plugin defining that class itself would already fatal on redeclaration today. So a call from that plugin looks implausible, but I cannot prove it from the repo. Worth a look at the deployed plugin directory before merging. Note the snapshot is dated Sep 2025.

## Tests

`tests/test-ProgramModule.php`, 8 tests. The registry test reads `getAvailablePrograms()` through reflection rather than restating it, so a module added later is covered without anyone remembering to list it twice.

Both new guards were mutation-checked:

| Mutation | Test that failed |
| --- | --- |
| `new $ClassName('')` (drop the token) | `test_active_programs_are_constructed_with_the_token` |
| `AffiliateLinker implements HookRegistrar` (drop the contract) | `test_every_registered_program_implements_the_contract` |

Full suite: 124 tests, 302 assertions, 0 skipped (was 116/286).

## Found along the way, filed separately

- The shared-constants half of #80 → #86.
- `AffiliateLinker::add_amazon_ajax()` requires a nonce (`check_ajax_referer('pof_affiliates_run', 'nonce')`) that no caller ever sends — `src/admin.ts` posts only `{action}`. The "Run amazon affiliate script now" button is dead. Pre-existing and untouched here → #87.
- `pof_save_meta` / `pof_meta_nonce`, named in #80, no longer exist anywhere — they went with the Bloom retirement (#69).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
